### PR TITLE
Coding style : Use python3.6 format-strings when relevant and extend …

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -38,18 +38,13 @@ def calculate_revision_updates(wrapper, old, new, attrs):
     new_keys = frozenset(list(new_dict.keys()))
 
     intersection = old_keys & new_keys
-    current_app.logger.debug(
-        "%d old, %d new, %d intersecting",
-        len(old_keys),
-        len(new_keys),
-        len(intersection),
-    )
-    # current_app.logger.debug('%s old, %s new, %s intersecting', old_keys, new_keys, intersection)
+    current_app.logger.debug(f"{len(old_keys)} old, {len(new_keys)} new, {len(intersection)} intersecting")
+    # current_app.logger.debug(f'{old_keys} old, {new_keys} new, {intersection} intersecting')
 
     # archive removed comments
     for k in old_keys - new_keys:
         o = old_dict[k]
-        current_app.logger.debug("Archiving %s", str(k))
+        current_app.logger.debug(f"Archiving {k!s}")
         o.archive()
 
     # filter new comments
@@ -63,10 +58,10 @@ def calculate_revision_updates(wrapper, old, new, attrs):
             if getattr(o, attr) != getattr(n, attr):
                 break
         else:
-            current_app.logger.debug("No changes for %s", str(k))
+            current_app.logger.debug(f"No changes for {k!s}")
             continue
         # archive old version
-        current_app.logger.debug("Archiving %s", str(k))
+        current_app.logger.debug(f"Archiving {k!s}")
         o.archive()
         n.revision = o.revision + 1
         updated_comments.append(n)
@@ -90,46 +85,37 @@ class Hashable(object):
         return hash(self.value)
 
     def __repr__(self):
-        return "{} ({})".format(str(self), hash(self))
+        return f"{str(self)} ({hash(self)})"
+
+
+class HashableComment(Hashable):
+
+    def __init__(self, comment):
+        super(HashableComment, self).__init__(comment, lambda c: (c.row_from, c.row_to))
+
+    def __str__(self):
+        return f"comment @ {self.value}"
+
+
+class HashableMarker(Hashable):
+
+    def __init__(self, marker):
+        super(HashableMarker, self).__init__(marker, lambda m: (m.row_from, m.row_to, m.column_from, m.column_to))
+
+    def __str__(self):
+        return "marker @ {0.row_from}:{0.column_from} - {0.row_to}:{0.column_to}".format(self.item)
 
 
 def update_file_comments(file_obj, new_comments):
 
-    class HashableComment(Hashable):
-
-        def __init__(self, comment):
-            super(HashableComment,
-                  self).__init__(comment, lambda c: (c.row_from, c.row_to))
-
-        def __str__(self):
-            return "comment @ {}".format(self.value)
-
-    updated_comments = calculate_revision_updates(HashableComment,
-                                                  file_obj.comments,
-                                                  new_comments,
-                                                  ["text", "sort_pos"])
-
+    updated_comments = calculate_revision_updates(HashableComment, file_obj.comments, new_comments, ["text", "sort_pos"])
     # add updated comments
     file_obj.comments += updated_comments
 
 
 def update_file_markers(file_obj, new_markers):
 
-    class HashableMarker(Hashable):
-
-        def __init__(self, marker):
-            super(HashableMarker, self).__init__(
-                marker, lambda m:
-                (m.row_from, m.row_to, m.column_from, m.column_to))
-
-        def __str__(self):
-            return "marker @ {0.row_from}:{0.column_from} - {0.row_to}:{0.column_to}".format(
-                self.item)
-
-    updated_markers = calculate_revision_updates(HashableMarker,
-                                                 file_obj.markers, new_markers,
-                                                 ["marker_class"])
-
+    updated_markers = calculate_revision_updates(HashableMarker, file_obj.markers, new_markers, ["marker_class"])
     # add updated comments
     file_obj.markers += updated_markers
 
@@ -149,14 +135,12 @@ def bug_save_editor_data():
             return create_json_response("Please create an entry first", 404)
 
         if not vuln_view.master_commit:
-            current_app.logger.error(
-                "Vuln (id: {:d}) has no linked Git commits!".format(
-                    vuln_view.id))
+            current_app.logger.error("Vuln (id: {vuln_view.id}) has no linked Git commits!")
             return create_json_response("Entry has no linked Git link!", 404)
 
         master_commit = vulnerability_details.getMasterCommit()
 
-        # print("DATA: {:s}".format(str(request.json)))
+        # print("DATA: {request.json}"
         old_files = master_commit.repository_files
         current_app.logger.debug("%d old files", len(old_files))
         # Flush any old custom content of this vulnerability first.
@@ -164,15 +148,11 @@ def bug_save_editor_data():
         for file in request.get_json():
             for of in old_files:
                 if of.file_path == file["path"] or of.file_hash == file["hash"]:
-                    current_app.logger.debug(
-                        "Found old file: %s",
-                        (file["path"], file["hash"], file["name"]))
+                    current_app.logger.debug("Found old file: %s", (file["path"], file["hash"], file["name"]))
                     file_obj = of
                     break
             else:
-                current_app.logger.debug(
-                    "Creating new file: %s",
-                    (file["path"], file["hash"], file["name"]))
+                current_app.logger.debug("Creating new file: %s", (file["path"], file["hash"], file["name"]))
                 file_obj = RepositoryFiles(
                     file_name=file["name"],
                     file_path=file["path"],

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -69,7 +69,6 @@ def calculate_revision_updates(wrapper, old, new, attrs):
 
 
 class Hashable(object):
-
     def __init__(self, item, key):
         self.item = item
         self.key = key
@@ -89,7 +88,6 @@ class Hashable(object):
 
 
 class HashableComment(Hashable):
-
     def __init__(self, comment):
         super(HashableComment, self).__init__(comment, lambda c: (c.row_from, c.row_to))
 
@@ -98,7 +96,6 @@ class HashableComment(Hashable):
 
 
 class HashableMarker(Hashable):
-
     def __init__(self, marker):
         super(HashableMarker, self).__init__(marker, lambda m: (m.row_from, m.row_to, m.column_from, m.column_to))
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -132,9 +132,7 @@ def is_authenticated():
 
 
 def login_required(redirect=False):
-
     def decorator(func):
-
         @wraps(func)
         def wrapper(*args, **kwargs):
             if not is_authenticated():
@@ -151,9 +149,7 @@ def login_required(redirect=False):
 
 
 def admin_required(redirect=False):
-
     def decorator(func):
-
         @wraps(func)
         def wrapper(*args, **kwargs):
             if not is_admin():

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -57,10 +57,7 @@ def authorized():
     if resp is None:
         error_message = "Access denied"
         if "error_reason" in request.args:
-            error_message += ": reason=%s error=%s" % (
-                request.args["error_reason"],
-                request.args["error_description"],
-            )
+            error_message += f": reason={request.args['error_reason']} error={request.args['error_description']}"
         return error_message
     # don't leak access_token into the session cookie
     # session['google_token'] = (resp['access_token'], '')
@@ -102,10 +99,7 @@ def load_user():
 
         user = User.query.filter_by(email=email).one_or_none()
         if not user:
-            user = User(
-                email=email,
-                full_name=data["name"],
-                profile_picture=data["picture"])
+            user = User(email=email, full_name=data["name"], profile_picture=data["picture"])
         else:
             user.full_name = data["name"]
             user.profile_picture = data["picture"]
@@ -146,8 +140,7 @@ def login_required(redirect=False):
             if not is_authenticated():
                 if redirect:
                     session["redirect_path"] = request.full_path
-                    return google.authorize(
-                        callback=url_for("auth.authorized", _external=True))
+                    return google.authorize(callback=url_for("auth.authorized", _external=True))
                 else:
                     return abort(401)
             return func(*args, **kwargs)
@@ -166,8 +159,7 @@ def admin_required(redirect=False):
             if not is_admin():
                 if redirect:
                     session["redirect_path"] = request.full_path
-                    return google.authorize(
-                        callback=url_for("auth.authorized", _external=True))
+                    return google.authorize(callback=url_for("auth.authorized", _external=True))
                 else:
                     return abort(401)
             return func(*args, **kwargs)

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -36,9 +36,9 @@ def product_view(vendor=None, product=None):
     entries = entries.filter(Nvd.id.in_(sub_query)).with_labels()
     entries = entries.outerjoin(Vulnerability, Nvd.cve_id == Vulnerability.cve_id)
     entries = entries.options(default_nvd_view_options)
-    #.options(lazyload(Nvd.cpes))
-    #entries = entries.order_by(
-    #    asc(Vulnerability.date_created), desc(Vulnerability.id))
+    # .options(lazyload(Nvd.cpes))
+    # entries = entries.order_by(
+    # asc(Vulnerability.date_created), desc(Vulnerability.id))
     product_vulns = entries.paginate(1, per_page=10)
     product_vulns = VulnViewSqlalchemyPaginationObjectWrapper(product_vulns)
 

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -26,12 +26,11 @@ from data.database import DEFAULT_DATABASE, Vulnerability, Nvd
 bp = Blueprint("product", __name__, url_prefix="/product")
 db = DEFAULT_DATABASE
 
+
 # Create a catch all route for product identifiers.
 @bp.route("/<vendor>/<product>")
 def product_view(vendor=None, product=None):
-    sub_query = db.session.query(Cpe.nvd_json_id).filter(
-            and_(Cpe.vendor == vendor, Cpe.product == product)
-        ).distinct()
+    sub_query = db.session.query(Cpe.nvd_json_id).filter(and_(Cpe.vendor == vendor, Cpe.product == product)).distinct()
 
     entries = db.session.query(Vulnerability, Nvd)
     entries = entries.filter(Nvd.id.in_(sub_query)).with_labels()
@@ -49,16 +48,11 @@ def product_view(vendor=None, product=None):
     for entry in entries_subset:
         if entry.Vulnerability is None or entry.Vulnerability.master_commit is None:
             continue
-        vuln_view = VulnerabilityView(
-            entry.Vulnerability, entry.Nvd, preview=True)
+        vuln_view = VulnerabilityView(entry.Vulnerability, entry.Nvd, preview=True)
         commits = [vuln_view.master_commit] + vuln_view.known_commits
         entry_repo_urls = [c.repo_url for c in commits]
         repo_urls += entry_repo_urls
     repo_urls = list(set(repo_urls))
 
     return render_template(
-        "product_view.html",
-        vendor=vendor,
-        product=product,
-        product_vulns=product_vulns,
-        repo_urls=repo_urls)
+        "product_view.html", vendor=vendor, product=product, product_vulns=product_vulns, repo_urls=repo_urls)

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -54,5 +54,8 @@ def product_view(vendor=None, product=None):
         repo_urls += entry_repo_urls
     repo_urls = list(set(repo_urls))
 
-    return render_template(
-        "product_view.html", vendor=vendor, product=product, product_vulns=product_vulns, repo_urls=repo_urls)
+    return render_template("product_view.html",
+                           vendor=vendor,
+                           product=product,
+                           product_vulns=product_vulns,
+                           repo_urls=repo_urls)

--- a/app/vulnerability/routes.py
+++ b/app/vulnerability/routes.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 import json
 import logging
-import urllib.request, urllib.error, urllib.parse
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from flask import (
     Blueprint,

--- a/app/vulnerability/routes.py
+++ b/app/vulnerability/routes.py
@@ -152,13 +152,12 @@ def file_provider(vuln_id):
     item_hash = request.args.get("item_hash", 0, type=str)
     item_path = request.args.get("item_path", None, type=str)
 
-    proxy_target = (
-        cfg.GCE_VCS_PROXY_URL + url_for(
-            "vcs_proxy.main_api",
-            repo_url=vulnerability_details.repo_url,
-            item_path=item_path,
-            item_hash=item_hash,
-        )[1:])
+    proxy_target = (cfg.GCE_VCS_PROXY_URL + url_for(
+        "vcs_proxy.main_api",
+        repo_url=vulnerability_details.repo_url,
+        item_path=item_path,
+        item_hash=item_hash,
+    )[1:])
     try:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False

--- a/app/vulnerability/routes.py
+++ b/app/vulnerability/routes.py
@@ -49,8 +49,7 @@ def view_vuln(vuln_id, use_template):
         vulnerability_details.validate()
     except InvalidIdentifierException as err:
         return flashError(str(err), "serve_index")
-    return render_template(
-        use_template, vulnerability_details=vulnerability_details)
+    return render_template(use_template, vulnerability_details=vulnerability_details)
 
 
 @bp.route("/vuln", methods=["POST"])
@@ -78,8 +77,7 @@ def vuln_view(vuln_id=None):
     use_template = "vuln_view_details.html"
     if vuln_view.annotated:
         use_template = "vuln_view_overview.html"
-    return render_template(
-        use_template, vulnerability_details=vulnerability_details)
+    return render_template(use_template, vulnerability_details=vulnerability_details)
 
 
 @bp.route("/<vuln_id>/details")
@@ -103,8 +101,7 @@ def vuln_file_tree(vuln_id):
     response_msg = master_commit.tree_cache
     if not response_msg:
         try:
-            vulnerability_details.fetch_tree_cache(
-                skip_errors=False, max_timeout=10)
+            vulnerability_details.fetch_tree_cache(skip_errors=False, max_timeout=10)
             response_msg = master_commit.tree_cache
         except urllib.error.HTTPError as err:
             status_code = err.code
@@ -127,8 +124,7 @@ def vuln_file_tree(vuln_id):
             content_type = "text/plain"
             response_msg = "VCS proxy is unreachable (it might be down)."
 
-    return Response(
-        response=response_msg, status=status_code, content_type=content_type)
+    return Response(response=response_msg, status=status_code, content_type=content_type)
 
 
 @bp.route("/<vuln_id>/annotation_data")
@@ -138,8 +134,7 @@ def annotation_data(vuln_id):
     vuln_view = vulnerability_details.vulnerability_view
     master_commit = vuln_view.master_commit
     if not master_commit:
-        logging.error("Vuln (id: {:d}) has no linked Git commits!".format(
-            vuln_view.id))
+        logging.error(f"Vuln (id: {vuln_view.id}) has no linked Git commits!")
         return create_json_response("Entry has no linked Git link!", 404)
 
     master_commit = vulnerability_details.getMasterCommit()
@@ -169,8 +164,7 @@ def file_provider(vuln_id):
         ctx.verify_mode = ssl.CERT_REQUIRED
         result = urllib.request.urlopen(proxy_target, context=ctx)
     except urllib.error.HTTPError as err:
-        return Response(
-            response=err.read(), status=err.code, content_type="text/plain")
+        return Response(response=err.read(), status=err.code, content_type="text/plain")
     return send_file(result, mimetype="application/octet-stream")
 
 
@@ -186,15 +180,12 @@ def embed(vuln_id):
         if not vuln_view:
             return bp.make_response(("No vulnerability found", 404))
         if not vuln_view.master_commit:
-            return bp.make_response(
-                ("Vuln (id: {:d}) has no linked Git commits!".format(
-                    vuln_view.id), 404))
+            return bp.make_response((f"Vuln (id: {vuln_view.id}) has no linked Git commits!", 404))
 
         master_commit = vulnerability_details.getMasterCommit()
         files_schema = RepositoryFilesSchema(many=True)
         # Hack to quickly retrieve the full data.
-        custom_data = json.loads(
-            files_schema.jsonify(master_commit.repository_files).data)
+        custom_data = json.loads(files_schema.jsonify(master_commit.repository_files).data)
         settings = {
             "section_id": section_id,
             "startLine": start_line,
@@ -225,8 +216,7 @@ def _create_vuln_internal(vuln_id=None):
         return flashError(str(err), "serve_index")
 
     if vulnerability.id:
-        logging.debug("Preexisting vulnerability entry found: %s",
-                      vulnerability.id)
+        logging.debug(f"Preexisting vulnerability entry found: {vulnerability.id}")
         delete_form = VulnerabilityDeleteForm()
         if delete_form.validate_on_submit():
             db.session.delete(vulnerability)
@@ -250,14 +240,10 @@ def _create_vuln_internal(vuln_id=None):
             form.populate_obj(vulnerability)
             db.session.add(vulnerability)
             db.session.commit()
-            logging.debug("Successfully created/updated entry: %s",
-                          vulnerability.id)
+            logging.debug(f"Successfully created/updated entry: {vulnerability.id}")
             flash("Successfully created/updated entry.", "success")
             return redirect(url_for("vuln.vuln_view", vuln_id=vulnerability.id))
         except InvalidIdentifierException as err:
             flashError(str(err))
 
-    return render_template(
-        "create_entry.html",
-        vulnerability_details=vulnerability_details,
-        form=form)
+    return render_template("create_entry.html", vulnerability_details=vulnerability_details, form=form)

--- a/app/vulnerability/views/details.py
+++ b/app/vulnerability/views/details.py
@@ -23,7 +23,6 @@ import urllib.request
 
 from app.vulnerability.views.vulnerability import VulnerabilityView
 
-
 from flask import current_app, request, url_for, g
 from werkzeug.routing import RequestRedirect
 from app.exceptions import InvalidIdentifierException
@@ -46,7 +45,6 @@ db = DEFAULT_DATABASE
 
 
 class VulnerabilityDetails:
-
     def __init__(self, vuln_id=None):
         self.suggested_id = vuln_id
         self.id = None
@@ -162,7 +160,7 @@ class VulnerabilityDetails:
         self.id = None
 
     def getSettings(self):
-        parent_hash = (None,)
+        parent_hash = (None, )
         if self.vulnerability_view:
             parent_hash = self.vulnerability_view.parent_commit
 
@@ -274,13 +272,12 @@ class VulnerabilityDetails:
             # Fetch the required data from our VCS proxy.
             try:
                 # Fetch the required data from our VCS proxy.
-                proxy_target = (
-                    cfg.GCE_VCS_PROXY_URL + url_for(
-                        "vcs_proxy.main_api",
-                        commit_link=self.commit_link,
-                        commit_hash=self.commit_hash,
-                        repo_url=self.repo_url,
-                    )[1:])
+                proxy_target = (cfg.GCE_VCS_PROXY_URL + url_for(
+                    "vcs_proxy.main_api",
+                    commit_link=self.commit_link,
+                    commit_hash=self.commit_hash,
+                    repo_url=self.repo_url,
+                )[1:])
 
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False

--- a/app/vulnerability/views/details.py
+++ b/app/vulnerability/views/details.py
@@ -67,18 +67,16 @@ class VulnerabilityDetails:
 
     def __repr__(self):
         args = [
-            "{}={!r}".format(name, value)
-            for name, value in inspect.getmembers(
-                self,
-                lambda m: not inspect.isfunction(m) and not inspect.ismethod(m))
+            f"{name}={value!r}"
+            for name, value in inspect.getmembers(self, lambda m: not inspect.isfunction(m) and not inspect.ismethod(m))
             if not name.startswith("_")
         ]
-        return "{}({})".format(type(self).__name__, ", ".join(args))
+        return f"{type(self).__name__}({', '.join(args)})"
 
     def update_details(self):
         """
-    Updates the database with pending vuln + dependencies modifications.
-    """
+        Updates the database with pending vuln + dependencies modifications.
+        """
         db.session.add(self._vulnerability)
         db.session.commit()
 
@@ -108,24 +106,20 @@ class VulnerabilityDetails:
         if self.suggested_id:
             if self.is_cve_id(self.suggested_id):
                 self.cve_id = self.suggested_id
-                logging.debug("Suggested id %r recognized as CVE",
-                              self.suggested_id)
+                logging.debug("Suggested id %r recognized as CVE", self.suggested_id)
             elif self.is_vcdb_id(self.suggested_id):
                 self.vcdb_id = self.suggested_id
-                logging.debug("Suggested id %r recognized as VCDB_ID",
-                              self.suggested_id)
+                logging.debug("Suggested id %r recognized as VCDB_ID", self.suggested_id)
             if request.method == "POST":
                 # Handle more complex IDs only via POST.
                 if self.is_commit_link(self.suggested_id):
                     self.commit_link = self.suggested_id
-                    logging.debug("Suggested id %r recognized as commit link",
-                                  self.suggested_id)
+                    logging.debug("Suggested id %r recognized as commit link", self.suggested_id)
                 elif self.is_repo_data(self.suggested_id):
                     repo_data = self.suggested_id.split("||")
                     self.repo_url = repo_data[0]
                     self.commit_hash = repo_data[1]
-                    logging.debug("Suggested id %r recognized as raw repo link",
-                                  self.suggested_id)
+                    logging.debug("Suggested id %r recognized as raw repo link", self.suggested_id)
 
         self._fetch_data()
 
@@ -141,8 +135,7 @@ class VulnerabilityDetails:
     def validate(self):
         self._set_id()
         if not self.id:
-            raise InvalidIdentifierException(
-                "Please provide a valid CVE ID or Git commit link.")
+            raise InvalidIdentifierException("Please provide a valid CVE ID or Git commit link.")
 
         # if request.path is '/vuln':
         #  if self.cve_id or self.vcdb_id:
@@ -173,40 +166,25 @@ class VulnerabilityDetails:
 
         file_provider_url = self.file_provider_url
         if file_provider_url:
-            file_provider_url = self.file_provider_url.replace(
-                VULN_ID_PLACEHOLDER, self.id)
+            file_provider_url = self.file_provider_url.replace(VULN_ID_PLACEHOLDER, self.id)
         file_ref_provider_url = self.file_ref_provider_url
         if file_ref_provider_url:
-            file_ref_provider_url = self.file_ref_provider_url.replace(
-                VULN_ID_PLACEHOLDER, self.id)
+            file_ref_provider_url = self.file_ref_provider_url.replace(VULN_ID_PLACEHOLDER, self.id)
 
         data = {
-            "commit_link":
-                self.commit_link,
-            "commit_hash":
-                self.commit_hash,
-            "repo_url":
-                self.repo_url,
-            "repo_name":
-                self.repo_name,
-            "tree_url":
-                url_for("vuln.vuln_file_tree", vuln_id=self.id),
-            "annotation_data_url":
-                url_for("vuln.annotation_data", vuln_id=self.id),
-            "file_provider_url":
-                file_provider_url,
-            "file_ref_provider_url":
-                file_ref_provider_url,
-            "file_url":
-                self.file_url,
-            "id":
-                self.id,
-            "parent_hash":
-                parent_hash,
-            "HASH_PLACEHOLDER":
-                HASH_PLACEHOLDER,
-            "PATH_PLACEHOLDER":
-                PATH_PLACEHOLDER,
+            "commit_link": self.commit_link,
+            "commit_hash": self.commit_hash,
+            "repo_url": self.repo_url,
+            "repo_name": self.repo_name,
+            "tree_url": url_for("vuln.vuln_file_tree", vuln_id=self.id),
+            "annotation_data_url": url_for("vuln.annotation_data", vuln_id=self.id),
+            "file_provider_url": file_provider_url,
+            "file_ref_provider_url": file_ref_provider_url,
+            "file_url": self.file_url,
+            "id": self.id,
+            "parent_hash": parent_hash,
+            "HASH_PLACEHOLDER": HASH_PLACEHOLDER,
+            "PATH_PLACEHOLDER": PATH_PLACEHOLDER,
         }
         if self.vulnerability_view.annotated:
             master_commit = self.getMasterCommit()
@@ -215,8 +193,7 @@ class VulnerabilityDetails:
                 # TODO: Consider refactoring this section. We currently also fetch
                 #  custom data from the backend.
                 # Hack to quickly retrieve the full data.
-                data["custom_data"] = json.loads(
-                    files_schema.jsonify(master_commit.repository_files).data)
+                data["custom_data"] = json.loads(files_schema.jsonify(master_commit.repository_files).data)
 
         return data
 
@@ -239,31 +216,27 @@ class VulnerabilityDetails:
         else:
             resource_url = self.repo_url if self.repo_url else self.commit_link
 
-        logging.info("Searching VCS handler for %s", resource_url)
+        logging.info(f"Searching VCS handler for {resource_url}")
         if not resource_url:
             return False
 
         vcs_handler = get_vcs_handler(current_app, resource_url)
         if not vcs_handler:
-            raise InvalidIdentifierException(
-                "Please provide a valid resource link.")
+            raise InvalidIdentifierException("Please provide a valid resource link.")
         self.repo_name = vcs_handler.repo_name
         self.file_provider_url = vcs_handler.getFileProviderUrl()
         self.file_ref_provider_url = vcs_handler.getRefFileProviderUrl()
         self.file_url = vcs_handler.getFileUrl()
         self.tree_url = vcs_handler.getTreeUrl()
-        self.commit_hash = (
-            self.commit_hash if self.commit_hash else vcs_handler.commit_hash)
+        self.commit_hash = (self.commit_hash if self.commit_hash else vcs_handler.commit_hash)
         if not self.commit_hash:
-            raise InvalidIdentifierException(
-                "Couldn't extract commit hash from given resource URL.")
+            raise InvalidIdentifierException("Couldn't extract commit hash from given resource URL.")
         return True
 
     @staticmethod
     def is_cve_id(id):
         # strict check from https://cve.mitre.org/cve/identifiers/tech-guidance.html
-        return (re.match(r"^CVE-\d{4}-(0\d{3}|[1-9]\d{3,})$", id, re.IGNORECASE)
-                is not None)
+        return (re.match(r"^CVE-\d{4}-(0\d{3}|[1-9]\d{3,})$", id, re.IGNORECASE) is not None)
 
     @staticmethod
     def is_vcdb_id(id):
@@ -282,8 +255,7 @@ class VulnerabilityDetails:
             self._vulnerability = Vulnerability.get_by_id(self.vcdb_id)
         elif self.cve_id:
             if not self.is_cve_id(self.cve_id):
-                raise InvalidIdentifierException(
-                    "Please provide a valid CVE ID.")
+                raise InvalidIdentifierException("Please provide a valid CVE ID.")
             self._vulnerability = Vulnerability.get_by_cve_id(self.cve_id)
 
     def _fetch_by_commit_hash(self):
@@ -312,8 +284,7 @@ class VulnerabilityDetails:
                 ctx.check_hostname = False
                 ctx.load_verify_locations(cafile=cfg.APP_CERT_FILE)
                 ctx.verify_mode = ssl.CERT_REQUIRED
-                result = urllib.request.urlopen(
-                    proxy_target, timeout=max_timeout, context=ctx)
+                result = urllib.request.urlopen(proxy_target, timeout=max_timeout, context=ctx)
                 master_commit.tree_cache = result.read()
                 self.update_details()
             except Exception as e:
@@ -350,8 +321,7 @@ class VulnerabilityDetails:
 
         if self._vulnerability or self._nvd_data:
             self.fetch_tree_cache()
-            self.vulnerability_view = VulnerabilityView(self._vulnerability,
-                                                        self._nvd_data)
+            self.vulnerability_view = VulnerabilityView(self._vulnerability, self._nvd_data)
 
     def get_or_create_vulnerability(self):
         if self._vulnerability:

--- a/app/vulnerability/views/details.py
+++ b/app/vulnerability/views/details.py
@@ -17,10 +17,12 @@ import json
 import logging
 import re
 import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from app.vulnerability.views.vulnerability import VulnerabilityView
 
-import urllib.request, urllib.error, urllib.parse
 
 from flask import current_app, request, url_for, g
 from werkzeug.routing import RequestRedirect

--- a/app/vulnerability/views/vulncode_db.py
+++ b/app/vulnerability/views/vulncode_db.py
@@ -113,7 +113,7 @@ class VulncodeDB:
         self.vcdb_pagination = VulnViewSqlalchemyPaginationObjectWrapper(self.vcdb_pagination)
 
         def filter_pagination_param(param):
-            filtered = re.sub('[^a-zA-Z\d\- <>:~]', '', param)
+            filtered = re.sub(r'[^a-zA-Z\d\- <>:~]', '', param)
             return filtered
 
         nvd_bookmarked_page = request.args.get('nvd_p', None)

--- a/app/vulnerability/views/vulncode_db.py
+++ b/app/vulnerability/views/vulncode_db.py
@@ -134,14 +134,12 @@ class VulncodeDB:
         num_comments = self.get_annotation_query(RepositoryFileComments)
         num_markers = self.get_annotation_query(RepositoryFileMarkers)
         num_both = num_comments.c.count + num_markers.c.count
-        self.top_contributors = (
-            db.session.query(
-                User,
-                func.coalesce(num_comments.c.count, 0).label("num_comments"),
-                func.coalesce(num_markers.c.count, 0).label("num_markers"),
-            ).outerjoin(num_comments, num_comments.c.creator_id == User.id).outerjoin(
-                num_markers,
-                num_markers.c.creator_id == User.id).filter(num_both > 0).order_by(num_both.desc()).limit(10).all())
+        self.top_contributors = (db.session.query(
+            User,
+            func.coalesce(num_comments.c.count, 0).label("num_comments"),
+            func.coalesce(num_markers.c.count, 0).label("num_markers"),
+        ).outerjoin(num_comments, num_comments.c.creator_id == User.id).outerjoin(
+            num_markers, num_markers.c.creator_id == User.id).filter(num_both > 0).order_by(num_both.desc()).limit(10).all())
 
     @staticmethod
     def get_annotation_query(model):
@@ -218,7 +216,6 @@ class VulnViewTypesetPaginationObjectWrapper(Paging):
   An sqlakeyset Paging object wrapper class which wraps Vuln/Nvd rows
   inside a VulnView.
   """
-
     def __init__(self, paginationObject):
         """
     :param paginationObject: A Flask SQLalchemy Pagination object.
@@ -241,7 +238,6 @@ class VulnViewSqlalchemyPaginationObjectWrapper(Pagination):
   A Flask SQLAlchemy Pagination object wrapper class which wraps Vuln/Nvd rows
   inside a VulnView.
   """
-
     def __init__(self, paginationObject):
         """
     :param paginationObject: A Flask SQLalchemy Pagination object.

--- a/app/vulnerability/views/vulncode_db.py
+++ b/app/vulnerability/views/vulncode_db.py
@@ -65,20 +65,16 @@ class VulncodeDB:
         # self.fetch_top_contributors()
 
         vcdb_entries = db.session.query(Vulnerability, Nvd)
-        vcdb_entries = vcdb_entries.outerjoin(
-            Nvd, Vulnerability.cve_id == Nvd.cve_id)
+        vcdb_entries = vcdb_entries.outerjoin(Nvd, Vulnerability.cve_id == Nvd.cve_id)
         vcdb_entries = vcdb_entries.options(default_nvd_view_options)
-        vcdb_entries = vcdb_entries.order_by(
-            asc(Vulnerability.date_created), desc(Vulnerability.id))
+        vcdb_entries = vcdb_entries.order_by(asc(Vulnerability.date_created), desc(Vulnerability.id))
         self.vcdb_entries = vcdb_entries
 
         nvd_entries = db.session.query(Nvd)
-        nvd_entries = nvd_entries.outerjoin(Vulnerability,
-                                            Nvd.cve_id == Vulnerability.cve_id)
+        nvd_entries = nvd_entries.outerjoin(Vulnerability, Nvd.cve_id == Vulnerability.cve_id)
         nvd_entries = nvd_entries.options(default_nvd_view_options)
         nvd_entries = nvd_entries.filter(Vulnerability.cve_id.is_(None))
-        nvd_entries = nvd_entries.order_by(
-            desc(Nvd.published_date), desc(Nvd.id))
+        nvd_entries = nvd_entries.order_by(desc(Nvd.published_date), desc(Nvd.id))
         self.nvd_entries = nvd_entries
 
         self.keyword = request.args.get("keyword", None, type=str)
@@ -100,8 +96,7 @@ class VulncodeDB:
                 #     FullTextSearch(escaped_keyword, Nvd, FullTextMode.BOOLEAN),
                 #     FullTextSearch(escaped_keyword, Vulnerability, FullTextMode.BOOLEAN))
                 apply_filter = or_(
-                    Nvd.descriptions.any(
-                        Description.value.like("%" + escaped_keyword + "%")),
+                    Nvd.descriptions.any(Description.value.like("%" + escaped_keyword + "%")),
                     Vulnerability.comment.like("%" + escaped_keyword + "%"),
                 )
 
@@ -114,10 +109,8 @@ class VulncodeDB:
 
         per_page = 7
         vcdb_page = request.args.get("vcdb_p", 1, type=int)
-        self.vcdb_pagination = self.vcdb_entries.paginate(
-            vcdb_page, per_page=per_page)
-        self.vcdb_pagination = VulnViewSqlalchemyPaginationObjectWrapper(
-            self.vcdb_pagination)
+        self.vcdb_pagination = self.vcdb_entries.paginate(vcdb_page, per_page=per_page)
+        self.vcdb_pagination = VulnViewSqlalchemyPaginationObjectWrapper(self.vcdb_pagination)
 
         def filter_pagination_param(param):
             filtered = re.sub('[^a-zA-Z\d\- <>:~]', '', param)
@@ -128,10 +121,8 @@ class VulncodeDB:
             nvd_bookmarked_page = filter_pagination_param(nvd_bookmarked_page)
             nvd_bookmarked_page = unserialize_bookmark(nvd_bookmarked_page)
 
-        self.nvd_pagination = get_page(
-            self.nvd_entries, per_page, page=nvd_bookmarked_page)
-        self.nvd_pagination = VulnViewTypesetPaginationObjectWrapper(
-            self.nvd_pagination.paging)
+        self.nvd_pagination = get_page(self.nvd_entries, per_page, page=nvd_bookmarked_page)
+        self.nvd_pagination = VulnViewTypesetPaginationObjectWrapper(self.nvd_pagination.paging)
         num_nvd_entries = db.session.query(Nvd).count()
         num_vuln_entries = db.session.query(Vulnerability).count()
         num_unique_nvd_estimate = num_nvd_entries - num_vuln_entries
@@ -148,17 +139,14 @@ class VulncodeDB:
                 User,
                 func.coalesce(num_comments.c.count, 0).label("num_comments"),
                 func.coalesce(num_markers.c.count, 0).label("num_markers"),
-            ).outerjoin(
-                num_comments, num_comments.c.creator_id == User.id).outerjoin(
-                    num_markers, num_markers.c.creator_id == User.id).filter(
-                        num_both > 0).order_by(num_both.desc()).limit(10).all())
+            ).outerjoin(num_comments, num_comments.c.creator_id == User.id).outerjoin(
+                num_markers,
+                num_markers.c.creator_id == User.id).filter(num_both > 0).order_by(num_both.desc()).limit(10).all())
 
     @staticmethod
     def get_annotation_query(model):
-        return (db.session.query(
-            model.creator_id.label("creator_id"),
-            func.count(1).label("count")).filter_by(active=True).group_by(
-                model.creator_id).subquery())
+        return (db.session.query(model.creator_id.label("creator_id"),
+                                 func.count(1).label("count")).filter_by(active=True).group_by(model.creator_id).subquery())
 
     # @measure_execution_time('NEW 1')
     # def _new_method(self):

--- a/app/vulnerability/views/vulnerability.py
+++ b/app/vulnerability/views/vulnerability.py
@@ -32,8 +32,7 @@ def getVulnerability(filter_by):
     if "cve_id" in filter_by:
         vulnerability = Vulnerability.get_by_cve_id(filter_by["cve_id"])
     elif "commit_hash" in filter_by:
-        vulnerability = Vulnerability.get_by_commit_hash(
-            filter_by["commit_hash"])
+        vulnerability = Vulnerability.get_by_commit_hash(filter_by["commit_hash"])
     else:
         current_app.logger.error("Invalid filter option received.")
         return None
@@ -73,14 +72,11 @@ class VulnerabilityView:
                         if relevant_file_path not in self.relevant_files:
                             patch_stats = "(" + patched_files["status"]
                             if patched_files["additions"] > 0:
-                                patch_stats += ", +" + str(
-                                    patched_files["additions"])
+                                patch_stats += ", +" + str(patched_files["additions"])
                             if patched_files["deletions"] > 0:
-                                patch_stats += ", -" + str(
-                                    patched_files["deletions"])
+                                patch_stats += ", -" + str(patched_files["deletions"])
                             patch_stats += ")"
-                            self.relevant_files.append(relevant_file_path +
-                                                       " " + patch_stats)
+                            self.relevant_files.append(relevant_file_path + " " + patch_stats)
             for commit in vulnerability.commits:
                 if commit is master_commit:
                     continue
@@ -98,8 +94,7 @@ class VulnerabilityView:
         if vulnerability.comment:
             self.comment = vulnerability.comment
 
-        if self.read_data_from_commit(vulnerability,
-                                      vulnerability.master_commit):
+        if self.read_data_from_commit(vulnerability, vulnerability.master_commit):
             self.master_commit = vulnerability.master_commit
 
         return True

--- a/app/vulnerability/views/vulnerability.py
+++ b/app/vulnerability/views/vulnerability.py
@@ -19,7 +19,7 @@ from flask import current_app
 from data.database import DEFAULT_DATABASE
 
 from data.models import (
-    Vulnerability,)
+    Vulnerability, )
 
 db = DEFAULT_DATABASE
 
@@ -40,7 +40,6 @@ def getVulnerability(filter_by):
 
 
 class VulnerabilityView:
-
     def read_data_from_commit(self, vulnerability, master_commit=None):
         if not master_commit:
             return True

--- a/cfg.py
+++ b/cfg.py
@@ -28,9 +28,7 @@ DEBUG = False
 MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "false").lower() == "true"
 
 # Enables connecting to the remote database using the cloud sql proxy.
-USE_REMOTE_DB_THROUGH_CLOUDSQL_PROXY = (
-    os.getenv("USE_REMOTE_DB_THROUGH_CLOUDSQL_PROXY",
-              "false").lower() == "true")
+USE_REMOTE_DB_THROUGH_CLOUDSQL_PROXY = (os.getenv("USE_REMOTE_DB_THROUGH_CLOUDSQL_PROXY", "false").lower() == "true")
 
 IS_PROD = IS_QA = IS_LOCAL = False
 if os.getenv("SERVER_SOFTWARE", "").startswith("Google App Engine/"):
@@ -44,8 +42,7 @@ if os.getenv("SERVER_SOFTWARE", "").startswith("Google App Engine/"):
     elif appname == os.environ["PROD_PROJECT_ID"]:
         IS_PROD = True
     else:
-        raise AssertionError(
-            "Deployed in unknown environment: %s.".format(appname))
+        raise AssertionError(f"Deployed in unknown environment: {appname}.")
 
 if not IS_PROD and not IS_QA:
     IS_LOCAL = True
@@ -77,10 +74,7 @@ else:
 def gen_connection_string():
     # if not on Google then use local MySQL
     if IS_PROD or IS_QA:
-        conn_template = (
-            "mysql+mysqldb://%s:%s@localhost:3306/_DB_NAME_?unix_socket=/cloudsql/%s"
-        )
-        return conn_template % (MYSQL_USER, MYSQL_PASS, MYSQL_CONNECTION_NAME)
+        return f"mysql+mysqldb://{MYSQL_USER}:{MYSQL_PASS}@localhost:3306/_DB_NAME_?unix_socket=/cloudsql/MYSQL_CONNECTION_NAME"
     else:
         use_name = MYSQL_USER
         use_pass = MYSQL_PASS
@@ -95,8 +89,7 @@ def gen_connection_string():
             use_name = os.environ["CLOUDSQL_NAME"]
             use_pass = os.environ["CLOUDSQL_PASS"]
             use_port = int(os.getenv("CLOUDSQL_PORT", 3307))
-        conn_template = "mysql+mysqldb://%s:%s@%s:%d/_DB_NAME_"
-        return conn_template % (use_name, use_pass, use_host, use_port)
+        return f"mysql+mysqldb://{use_name}:{use_pass}@{use_host}:{use_port}/_DB_NAME_"
 
 
 SQLALCHEMY_DATABASE_URI = gen_connection_string().replace("_DB_NAME_", "main")
@@ -122,10 +115,7 @@ SECRET_KEY = os.getenv("COOKIE_SECRET_KEY", "")
 
 PATCH_REGEX = r".*(github\.com|\.git|\.patch|\/hg\.|\/\+\/)"
 
-GOOGLE_OAUTH = {
-    "consumer_key": os.getenv("OAUTH_CONSUMER_KEY", ""),
-    "consumer_secret": os.getenv("OAUTH_CONSUMER_SECRET", "")
-}
+GOOGLE_OAUTH = {"consumer_key": os.getenv("OAUTH_CONSUMER_KEY", ""), "consumer_secret": os.getenv("OAUTH_CONSUMER_SECRET", "")}
 
 # Make sure relevant properties are always set for QA and PROD.
 if IS_PROD or IS_QA:

--- a/crawl_patches.py
+++ b/crawl_patches.py
@@ -81,24 +81,20 @@ def dump_query(query, filter_columns=None):
     num_rows = 5
 
     if hasattr(query, "statement"):
-        sql_query = str(
-            query.statement.compile(
-                dialect=None, compile_kwargs={"literal_binds": True}))
+        sql_query = str(query.statement.compile(dialect=None, compile_kwargs={"literal_binds": True}))
     else:
         sql_query = str(query)
 
-    formatted_sql_query = sqlparse.format(
-        sql_query, reindent=True, keyword_case="upper")
-    highlighted_sql_query = highlight(formatted_sql_query, SqlLexer(),
-                                      TerminalFormatter())
+    formatted_sql_query = sqlparse.format(sql_query, reindent=True, keyword_case="upper")
+    highlighted_sql_query = highlight(formatted_sql_query, SqlLexer(), TerminalFormatter())
     print("Query:")
-    print("-" * 15 + "\n%s" % highlighted_sql_query + "-" * 15)
+    print(f"{'-' * 15}\n{highlighted_sql_query}{'-' * 15}")
 
     df = pd.read_sql(query.statement, CVE_DB_ENGINE)
     if filter_columns:
         df = df[filter_columns]
 
-    print("Results: {}; showing first {}:".format(df.shape[0], num_rows))
+    print(f"Results: {df.shape[0]}; showing first {num_rows}:")
     print(df.head(num_rows))
 
 
@@ -111,14 +107,13 @@ def get_nvd_github_patch_candidates():
     patch_regex = r"github\.com/([^/]+)/([^/]+)/commit/([^/]+)"
 
     sub_query = (
-        db.session.query(func.min(Reference.id)).filter(
-            Reference.link.op("regexp")(patch_regex)).group_by(
-                Reference.nvd_json_id))
+        db.session.query(func.min(Reference.id)).filter(Reference.link.op("regexp")(patch_regex)).group_by(
+            Reference.nvd_json_id))
     github_commit_candidates = (
         db.session.query(Nvd.cve_id, Reference.link, Vulnerability).select_from(
-            join(Nvd, Reference).outerjoin(
-                Vulnerability, Nvd.cve_id == Vulnerability.cve_id)).filter(
-                    Reference.id.in_(sub_query)).with_labels())
+            join(Nvd,
+                 Reference).outerjoin(Vulnerability,
+                                      Nvd.cve_id == Vulnerability.cve_id)).filter(Reference.id.in_(sub_query)).with_labels())
 
     return github_commit_candidates
 
@@ -128,7 +123,7 @@ def create_vcdb_entry(cve_id, commit_link=None):
     if commit_link:
         vcs_handler = get_vcs_handler(app, commit_link)
         if not vcs_handler:
-            print("Can't parse Vcs link: {}".format(commit_link))
+            print(f"Can't parse Vcs link: {commit_link}")
             return None
         vuln_commit = VulnerabilityGitCommits(
             commit_link=commit_link,
@@ -165,7 +160,7 @@ def store_or_update_vcdb_entries(github_commit_candidates):
 
         vulnerability_suggestion = create_vcdb_entry(nvd_cve_id, commit_link)
         if not vulnerability_suggestion:
-            print("[-] Invalid data detected for cve_id: {}".format(nvd_cve_id))
+            print(f"[-] Invalid data detected for cve_id: {nvd_cve_id}")
             stats["skipped"] += 1
             continue
 
@@ -180,8 +175,7 @@ def store_or_update_vcdb_entries(github_commit_candidates):
                 raise Exception("Incorrect vulnerability cve_id!")
 
             if existing_vcdb_vulnerability.master_commit:
-                if (existing_vcdb_vulnerability.master_commit.repo_owner !=
-                        vulnerability_suggestion.master_commit.repo_owner):
+                if (existing_vcdb_vulnerability.master_commit.repo_owner != vulnerability_suggestion.master_commit.repo_owner):
                     has_changed = True
 
                 if (existing_vcdb_vulnerability.master_commit.commit_link !=
@@ -196,10 +190,8 @@ def store_or_update_vcdb_entries(github_commit_candidates):
                 stats["updated"] += 1
                 # TODO: Consider updating more attributes here.
                 # Update only the commit_link and repo_owner for now.
-                existing_vcdb_vulnerability.master_commit.commit_link = (
-                    vulnerability_suggestion.master_commit.commit_link)
-                existing_vcdb_vulnerability.master_commit.repo_owner = (
-                    vulnerability_suggestion.master_commit.repo_owner)
+                existing_vcdb_vulnerability.master_commit.commit_link = (vulnerability_suggestion.master_commit.commit_link)
+                existing_vcdb_vulnerability.master_commit.repo_owner = (vulnerability_suggestion.master_commit.repo_owner)
                 db.session.add(existing_vcdb_vulnerability)
             else:
                 stats["idle"] += 1
@@ -230,25 +222,19 @@ def print_stats(stats):
 def update_oss_table():
     # Fetch all distinct vendor, product tuples from the main table.
     unique_products = db.session.query(Cpe.vendor, Cpe.product)
-    unique_products = unique_products.select_from(
-        join(Nvd, Cpe).outerjoin(Vulnerability,
-                                 Vulnerability.cve_id == Nvd.cve_id))
+    unique_products = unique_products.select_from(join(Nvd, Cpe).outerjoin(Vulnerability, Vulnerability.cve_id == Nvd.cve_id))
     unique_products = unique_products.filter(Vulnerability.cve_id.isnot(None))
     unique_products = unique_products.distinct(Cpe.vendor, Cpe.product)
     # Fetch only entries which are not already contained in OpenSourceProducts.
     unique_products = unique_products.outerjoin(
-        OpenSourceProducts,
-        and_(Cpe.vendor == OpenSourceProducts.vendor,
-             Cpe.product == OpenSourceProducts.product))
-    unique_products = unique_products.filter(
-        OpenSourceProducts.vendor.is_(None))
+        OpenSourceProducts, and_(Cpe.vendor == OpenSourceProducts.vendor, Cpe.product == OpenSourceProducts.product))
+    unique_products = unique_products.filter(OpenSourceProducts.vendor.is_(None))
     dump_query(unique_products)
 
     # We don't do any updates for now.
     created = 0
     for entry in unique_products:
-        new_entry = OpenSourceProducts(
-            vendor=entry.vendor, product=entry.product)
+        new_entry = OpenSourceProducts(vendor=entry.vendor, product=entry.product)
         db.session.add(new_entry)
         sys.stdout.write(".")
         sys.stdout.flush()
@@ -262,16 +248,12 @@ def update_oss_table():
 
 def create_oss_entries():
     nvd_entries = db.session.query(Nvd.cve_id, Vulnerability)
-    nvd_entries = nvd_entries.select_from(
-        join(Nvd,
-             Cpe).outerjoin(Vulnerability,
-                            Nvd.cve_id == Vulnerability.cve_id)).with_labels()
+    nvd_entries = nvd_entries.select_from(join(Nvd, Cpe).outerjoin(Vulnerability,
+                                                                   Nvd.cve_id == Vulnerability.cve_id)).with_labels()
     nvd_entries = nvd_entries.filter(Vulnerability.cve_id.is_(None))
     #nvd_entries = nvd_entries.options(default_nvd_view_options)
-    nvd_entries = nvd_entries.join(
-        OpenSourceProducts,
-        and_(Cpe.vendor == OpenSourceProducts.vendor,
-             Cpe.product == OpenSourceProducts.product))
+    nvd_entries = nvd_entries.join(OpenSourceProducts,
+                                   and_(Cpe.vendor == OpenSourceProducts.vendor, Cpe.product == OpenSourceProducts.product))
     nvd_entries = nvd_entries.distinct(Nvd.cve_id)
     return nvd_entries
 
@@ -280,9 +262,7 @@ def create_oss_entries():
 def start_crawling():
     """- See how to best convert those entries into VCDB entries."""
 
-    write_highlighted(
-        "1) Fetching entries from NVD with a direct github.com/*/commit/* commit link."
-    )
+    write_highlighted("1) Fetching entries from NVD with a direct github.com/*/commit/* commit link.")
     github_commit_candidates = get_nvd_github_patch_candidates()
     #update_oss_table()
     #exit()

--- a/crawl_patches.py
+++ b/crawl_patches.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 import sys
 import sqlparse
@@ -34,15 +33,12 @@ from data.models import Nvd, Reference, Vulnerability, VulnerabilityGitCommits, 
 from data.models.nvd import default_nvd_view_options
 from data.database import DEFAULT_DATABASE, init_app as init_db
 
-
 if "MYSQL_CONNECTION_NAME" not in os.environ:
     print("[~] Executed outside AppEngine context. Manually loading config.")
     manually_read_app_config()
 
-
 sys.path.append("third_party/")
 pd.set_option("display.max_colwidth", -1)
-
 
 app = Flask(__name__, static_url_path="", template_folder="templates")
 # Load the Flask configuration parameters from a global config file.
@@ -101,14 +97,11 @@ def get_nvd_github_patch_candidates():
 
     patch_regex = r"github\.com/([^/]+)/([^/]+)/commit/([^/]+)"
 
-    sub_query = (
-        db.session.query(func.min(Reference.id)).filter(Reference.link.op("regexp")(patch_regex)).group_by(
-            Reference.nvd_json_id))
-    github_commit_candidates = (
-        db.session.query(Nvd.cve_id, Reference.link, Vulnerability).select_from(
-            join(Nvd,
-                 Reference).outerjoin(Vulnerability,
-                                      Nvd.cve_id == Vulnerability.cve_id)).filter(Reference.id.in_(sub_query)).with_labels())
+    sub_query = (db.session.query(func.min(Reference.id)).filter(Reference.link.op("regexp")(patch_regex)).group_by(
+        Reference.nvd_json_id))
+    github_commit_candidates = (db.session.query(Nvd.cve_id, Reference.link, Vulnerability).select_from(
+        join(Nvd, Reference).outerjoin(Vulnerability,
+                                       Nvd.cve_id == Vulnerability.cve_id)).filter(Reference.id.in_(sub_query)).with_labels())
 
     return github_commit_candidates
 

--- a/data/database.py
+++ b/data/database.py
@@ -53,8 +53,7 @@ class Database:
         insp = reflection.Inspector.from_engine(self.db.engine)
         for name in insp.get_table_names():
             for index in insp.get_indexes(name):
-                self.db.engine.execute("DROP INDEX IF EXISTS {:s}".format(
-                    index["name"]))
+                self.db.engine.execute(f"DROP INDEX IF EXISTS {index['name']}")
         self.app.logger.warning("!!! Attention !!! FLUSHED the main database.")
 
         # Create the database from all model definitions.

--- a/data/forms/__init__.py
+++ b/data/forms/__init__.py
@@ -28,7 +28,6 @@ from data.models.base import db
 
 
 class ModelFieldList(FieldList):
-
     def __init__(self, *args, **kwargs):
         self.model = kwargs.pop("model", None)
         super(ModelFieldList, self).__init__(*args, **kwargs)

--- a/data/forms/__init__.py
+++ b/data/forms/__init__.py
@@ -48,30 +48,21 @@ class ModelFieldList(FieldList):
 
 
 class CommitLinksForm(FlaskForm):
-    commit_link = StringField(
-        "Commit Link", validators=[validators.DataRequired(),
-                                   validators.URL()])
-    repo_name = StringField(
-        "Repository Name", validators=[validators.DataRequired()])
+    commit_link = StringField("Commit Link", validators=[validators.DataRequired(), validators.URL()])
+    repo_name = StringField("Repository Name", validators=[validators.DataRequired()])
 
-    repo_url = StringField(
-        "Git Repo URL", validators=[validators.Optional(),
-                                    validators.URL()])
+    repo_url = StringField("Git Repo URL", validators=[validators.Optional(), validators.URL()])
     commit_hash = StringField("Commit Hash", validators=[])
 
     def __init__(self, csrf_enabled=False, *args, **kwargs):
-        super(CommitLinksForm, self).__init__(
-            csrf_enabled=csrf_enabled, *args, **kwargs)
+        super(CommitLinksForm, self).__init__(csrf_enabled=csrf_enabled, *args, **kwargs)
 
 
 class VulnerabilityResourcesForm(FlaskForm):
-    link = StringField(
-        "Link", validators=[validators.DataRequired(),
-                            validators.URL()])
+    link = StringField("Link", validators=[validators.DataRequired(), validators.URL()])
 
     def __init__(self, csrf_enabled=False, *args, **kwargs):
-        super(FlaskForm, self).__init__(
-            csrf_enabled=csrf_enabled, *args, **kwargs)
+        super(FlaskForm, self).__init__(csrf_enabled=csrf_enabled, *args, **kwargs)
 
 
 class VulnerabilityDetailsForm(FlaskForm):
@@ -87,15 +78,10 @@ class VulnerabilityDetailsForm(FlaskForm):
     cve_id = StringField(
         "CVE-ID (if applicable)",
         filters=[lambda x: x and str(x).upper().strip(), lambda x: x or None],
-        validators=[
-            validators.Optional(),
-            validators.Regexp(r"^CVE-\d{4}-\d+$")
-        ],
+        validators=[validators.Optional(), validators.Regexp(r"^CVE-\d{4}-\d+$")],
     )
-    comment = TextAreaField(
-        "High-Level Bug Overview", validators=[validators.DataRequired()])
-    additional_resources = ModelFieldList(
-        FormField(VulnerabilityResourcesForm), model=VulnerabilityResources)
+    comment = TextAreaField("High-Level Bug Overview", validators=[validators.DataRequired()])
+    additional_resources = ModelFieldList(FormField(VulnerabilityResourcesForm), model=VulnerabilityResources)
     submit = SubmitField("Create/Update")
 
 

--- a/data/models/base.py
+++ b/data/models/base.py
@@ -63,9 +63,7 @@ class NvdBase(db.Model):
             # Disable Index
             attribute.index = None
             # Create a custom index here.
-            indices += (Index(
-                idx_format.format(tbl_name=cls.__tablename__, col_name=key),
-                key),)
+            indices += (Index(idx_format.format(tbl_name=cls.__tablename__, col_name=key), key),)
         return indices + ({"schema": "cve"},)
 
 

--- a/data/models/base.py
+++ b/data/models/base.py
@@ -22,7 +22,6 @@ from sqlalchemy.ext.declarative import declared_attr
 # Note: This will slightly degrade performance. It might be better to adjust
 #       MariaDB server settings.
 class SQLAlchemy(SQLAlchemyBase):
-
     def apply_pool_defaults(self, app, options):
         super(SQLAlchemy, self).apply_pool_defaults(app, options)
         options["pool_pre_ping"] = True
@@ -63,8 +62,8 @@ class NvdBase(db.Model):
             # Disable Index
             attribute.index = None
             # Create a custom index here.
-            indices += (Index(idx_format.format(tbl_name=cls.__tablename__, col_name=key), key),)
-        return indices + ({"schema": "cve"},)
+            indices += (Index(idx_format.format(tbl_name=cls.__tablename__, col_name=key), key), )
+        return indices + ({"schema": "cve"}, )
 
 
 class CweBase(db.Model):

--- a/data/models/nvd.py
+++ b/data/models/nvd.py
@@ -30,8 +30,7 @@ class Affect(nvd_template.Affect, NvdBase):
 
 
 class Cpe(nvd_template.Cpe, NvdBase):
-    nvd_json_id = Column(
-        INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
+    nvd_json_id = Column(INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
 
 
 Index("idx_cpe_vendor_product", Cpe.vendor, Cpe.product)
@@ -59,17 +58,12 @@ Index("idx_cvsss2_extra_nvd_json_id", Cvss2Extra.nvd_json_id)
 
 
 class Cvss3(nvd_template.Cvss3, NvdBase):
-    nvd_json_id = Column(
-        INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
+    nvd_json_id = Column(INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
 
 
 class Cwe(nvd_template.Cwe, NvdBase):
-    nvd_json_id = Column(
-        INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
-    cwe_data = relationship(
-        CweData,
-        primaryjoin="foreign(CweData.cwe_id) == Cwe.cwe_id",
-        uselist=False)
+    nvd_json_id = Column(INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
+    cwe_data = relationship(CweData, primaryjoin="foreign(CweData.cwe_id) == Cwe.cwe_id", uselist=False)
 
     @property
     def cwe_name(self):
@@ -77,8 +71,7 @@ class Cwe(nvd_template.Cwe, NvdBase):
 
 
 class Description(nvd_template.Description, NvdBase):
-    nvd_json_id = Column(
-        INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
+    nvd_json_id = Column(INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
 
 
 class EnvCpe(nvd_template.EnvCpe, NvdBase):
@@ -111,8 +104,7 @@ Index("idx_nvd_xmls_cveid", NvdXml.cve_id)
 
 
 class Reference(nvd_template.Reference, NvdBase):
-    nvd_json_id = Column(
-        INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
+    nvd_json_id = Column(INTEGER(10), ForeignKey("cve.nvd_jsons.id"), index=True)
 
 
 class Nvd(nvd_template.NvdJson, NvdBase):
@@ -147,16 +139,13 @@ class Nvd(nvd_template.NvdJson, NvdBase):
 
     @classmethod
     def get_all_by_link_substring(cls, substring):
-        return (cls.query.join(Nvd.references).filter(
-            Reference.link.contains(substring)).order_by(
-                Nvd.created_at.desc()).distinct())
+        return (cls.query.join(Nvd.references).filter(Reference.link.contains(substring)).order_by(
+            Nvd.created_at.desc()).distinct())
 
     @classmethod
     def get_all_by_link_regex(cls, regex):
-        return (cls.query.join(Nvd.references, aliased=True).filter(
-            Reference.link.op("regexp")(regex)).order_by(
-                Nvd.created_at.desc()).distinct().options(
-                    default_nvd_view_options))
+        return (cls.query.join(Nvd.references, aliased=True).filter(Reference.link.op("regexp")(regex)).order_by(
+            Nvd.created_at.desc()).distinct().options(default_nvd_view_options))
 
     @classmethod
     def get_by_commit_hash(cls, commit_hash):
@@ -164,8 +153,7 @@ class Nvd(nvd_template.NvdJson, NvdBase):
 
     @classmethod
     def get_by_cve_id(cls, cve_id):
-        return (cls.query.filter_by(
-            cve_id=cve_id).options(default_nvd_view_options).first())
+        return (cls.query.filter_by(cve_id=cve_id).options(default_nvd_view_options).first())
 
     @property
     def description(self):
@@ -182,11 +170,9 @@ Index("idx_nvd_jsons_cveid", Nvd.cve_id)
 
 load_only_cpe_product = joinedload(Nvd.cpes).load_only(Cpe.vendor, Cpe.product)
 load_only_cwe_subset = joinedload(Nvd.cwes).load_only(Cwe.cwe_id)
-load_only_cwe_subset = load_only_cwe_subset.joinedload(Cwe.cwe_data).load_only(
-    CweData.cwe_name)
+load_only_cwe_subset = load_only_cwe_subset.joinedload(Cwe.cwe_data).load_only(CweData.cwe_name)
 load_only_base_score = joinedload(Nvd.cvss3).load_only(Cvss3.base_score)
-load_only_description_value = joinedload(Nvd.descriptions).load_only(
-    Description.value)
+load_only_description_value = joinedload(Nvd.descriptions).load_only(Description.value)
 default_nvd_view_options = [
     load_only_cpe_product,
     load_only_cwe_subset,

--- a/data/models/vulnerability.py
+++ b/data/models/vulnerability.py
@@ -50,7 +50,6 @@ class VulnerabilityResources(MainBase):
 
 
 class CreatorSchema(MarshmallowBase):
-
     class Meta:
         model = User
 
@@ -68,7 +67,6 @@ class RepositoryFileMarkers(RevisionMixin, MainBase):
 
 
 class RepositoryFileMarkersSchema(MarshmallowBase):
-
     class Meta(MarshmallowBase.Meta):
         model = RepositoryFileMarkers
 
@@ -87,7 +85,6 @@ class RepositoryFileComments(RevisionMixin, MainBase):
 
 
 class RepositoryFileCommentsSchema(MarshmallowBase):
-
     class Meta(MarshmallowBase.Meta):
         model = RepositoryFileComments
         exclude = ["archived_at", "active"]
@@ -310,16 +307,14 @@ Index("idx_oss_products_main", OpenSourceProducts.vendor, OpenSourceProducts.pro
 # TODO: Refactor these filters. We might want to use them as lazy loads instead.
 # Currently, querying like this eats up quite some time.
 # See for example: /CVE-2014-0160
-load_relationships1 = (
-    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.repository_files,
-                                                 VulnerabilityGitCommits.comments).joinedload(RepositoryFiles.comments))
+load_relationships1 = (joinedload(Vulnerability.commits).joinedload(
+    VulnerabilityGitCommits.repository_files, VulnerabilityGitCommits.comments).joinedload(RepositoryFiles.comments))
 
-load_relationships2 = (
-    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.repository_files).joinedload(RepositoryFiles.markers))
+load_relationships2 = (joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.repository_files).joinedload(
+    RepositoryFiles.markers))
 
-load_relationships3 = (
-    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.comments).joinedload(
-        RepositoryFileComments.repository_file))
+load_relationships3 = (joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.comments).joinedload(
+    RepositoryFileComments.repository_file))
 
 default_vuln_view_options = [
     load_relationships1,

--- a/data/models/vulnerability.py
+++ b/data/models/vulnerability.py
@@ -18,8 +18,7 @@ from app.exceptions import InvalidIdentifierException
 from data.utils import populate_models
 from data.models.base import MainBase, ma
 from data.models.user import User
-from sqlalchemy import (Boolean, Column, Integer, String, Text, ForeignKey,
-                        Index, DateTime, UniqueConstraint, func)
+from sqlalchemy import (Boolean, Column, Integer, String, Text, ForeignKey, Index, DateTime, UniqueConstraint, func)
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.orm import relationship, deferred, joinedload
 from lib.vcs_management import get_vcs_handler
@@ -196,8 +195,7 @@ class VulnerabilityGitCommits(MainBase):
             # TODO: Refactor this apporach of retrieving github.com urls.
             if self.commit_link and "github.com" in self.commit_link:
                 if self.repo_owner and self.repo_name:
-                    return ("https://github.com/" + self.repo_owner + "/" +
-                            self.repo_name)
+                    return ("https://github.com/" + self.repo_owner + "/" + self.repo_name)
         return self._repo_url
 
     @repo_url.setter
@@ -221,8 +219,7 @@ class VulnerabilityGitCommits(MainBase):
         #   raise InvalidIdentifierException('Please provide a valid commit link.')
         if commit_link:
             if not commit_link.startswith("http"):
-                raise InvalidIdentifierException(
-                    "Please provide a valid commit link.")
+                raise InvalidIdentifierException("Please provide a valid commit link.")
 
         self._commit_link = commit_link
 
@@ -239,8 +236,7 @@ class VulnerabilityGitCommits(MainBase):
         if repo_url:
             vcs_handler = get_vcs_handler(None, repo_url)
             if not vcs_handler:
-                raise InvalidIdentifierException(
-                    "Please provide a valid git repo URL.")
+                raise InvalidIdentifierException("Please provide a valid git repo URL.")
             self.repo_url = repo_url
         self.commit_link = commit_link
         self.commit_hash = commit_hash
@@ -250,8 +246,7 @@ class Vulnerability(MainBase):
     # __fulltext_columns__ = ('comment',)
     __tablename__ = "vulnerability"
     comment = Column(Text, nullable=False)
-    date_created = Column(
-        DateTime, default=func.current_timestamp(), index=True)
+    date_created = Column(DateTime, default=func.current_timestamp(), index=True)
     exploit_exists = Column(Boolean, default=False)
     # N.B. Don't use a ForeignKey constraint on NVD here as the nvd data might be
     # updated dynamically (e.g. row deleted and then added by go-cve-dictionary).
@@ -288,22 +283,20 @@ class Vulnerability(MainBase):
         return None
 
     def __repr__(self):
-        return "Vulnerability Info({:s})".format(vars(self))
+        return f"Vulnerability Info({vars(self)})"
 
     @classmethod
     def get_by_id(cls, id):
-        return cls.query.filter_by(
-            id=id).options(default_vuln_view_options).first()
+        return cls.query.filter_by(id=id).options(default_vuln_view_options).first()
 
     @classmethod
     def get_by_cve_id(cls, cve_id):
-        return (cls.query.filter_by(
-            cve_id=cve_id).options(default_vuln_view_options).first())
+        return (cls.query.filter_by(cve_id=cve_id).options(default_vuln_view_options).first())
 
     @classmethod
     def get_by_commit_hash(cls, commit_hash):
-        return (cls.query.join(Vulnerability.commits, aliased=True).filter_by(
-            commit_hash=commit_hash).options(default_vuln_view_options).first())
+        return (cls.query.join(Vulnerability.commits,
+                               aliased=True).filter_by(commit_hash=commit_hash).options(default_vuln_view_options).first())
 
 
 class OpenSourceProducts(MainBase):
@@ -312,29 +305,21 @@ class OpenSourceProducts(MainBase):
     product = Column(String(255), nullable=False)
 
 
-Index(
-    "idx_oss_products_main",
-    OpenSourceProducts.vendor,
-    OpenSourceProducts.product,
-    unique=True)
+Index("idx_oss_products_main", OpenSourceProducts.vendor, OpenSourceProducts.product, unique=True)
 
 # TODO: Refactor these filters. We might want to use them as lazy loads instead.
 # Currently, querying like this eats up quite some time.
 # See for example: /CVE-2014-0160
 load_relationships1 = (
-    joinedload(Vulnerability.commits).joinedload(
-        VulnerabilityGitCommits.repository_files,
-        VulnerabilityGitCommits.comments).joinedload(RepositoryFiles.comments))
+    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.repository_files,
+                                                 VulnerabilityGitCommits.comments).joinedload(RepositoryFiles.comments))
 
 load_relationships2 = (
-    joinedload(Vulnerability.commits).joinedload(
-        VulnerabilityGitCommits.repository_files).joinedload(
-            RepositoryFiles.markers))
+    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.repository_files).joinedload(RepositoryFiles.markers))
 
 load_relationships3 = (
-    joinedload(Vulnerability.commits).joinedload(
-        VulnerabilityGitCommits.comments).joinedload(
-            RepositoryFileComments.repository_file))
+    joinedload(Vulnerability.commits).joinedload(VulnerabilityGitCommits.comments).joinedload(
+        RepositoryFileComments.repository_file))
 
 default_vuln_view_options = [
     load_relationships1,

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 pylint
-yapf
+yapf>=0.28
 astroid==1.6.1
 pyyaml
 Flask==1.0.2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       MYSQL_ROOT_PASSWORD: pass
     # Publishing mysql port as 3308 for debugging purposes.
     ports:
-      - "3308:3306"
+      - "3306:3306" # Development config
     expose:
       - "3306"
 
@@ -59,4 +59,3 @@ services:
     # The main application will be reachable from your host on http://127.0.0.1:8080
     ports:
       - "8080:8080"
-

--- a/format.sh
+++ b/format.sh
@@ -42,7 +42,7 @@ fi
 if which yapf &>/dev/null
 then
   info 'Formatting python files with yapf'
-  YAPF_STYLE='{based_on_style: chromium, indent_width: 4, column_limit: 128}'
+  YAPF_STYLE='{based_on_style: pep8, indent_width: 4, column_limit: 128}'
   find . -maxdepth 1 -name "*.py" -print -exec yapf -i --style="${YAPF_STYLE}" {} \; | awk '{print "Reformatting "$1}'
   yapf -p -vv -i --recursive app lib data tests --style="${YAPF_STYLE}" || fatal 'Error during formatting python files'
 else

--- a/format.sh
+++ b/format.sh
@@ -42,7 +42,7 @@ fi
 if which yapf &>/dev/null
 then
   info 'Formatting python files with yapf'
-  YAPF_STYLE='{based_on_style: chromium, indent_width: 4}'
+  YAPF_STYLE='{based_on_style: chromium, indent_width: 4, column_limit: 128}'
   find . -maxdepth 1 -name "*.py" -print -exec yapf -i --style="${YAPF_STYLE}" {} \; | awk '{print "Reformatting "$1}'
   yapf -p -vv -i --recursive app lib data tests --style="${YAPF_STYLE}" || fatal 'Error during formatting python files'
 else

--- a/gce_vcs_proxy.py
+++ b/gce_vcs_proxy.py
@@ -97,10 +97,10 @@ def main_api():
     if item_hash:
         content = vcs_handler.getFileContent(item_hash, item_path)
         if not content:
-            err = "Could not retrieve object with hash {}.".format(item_hash)
+            err = f"Could not retrieve object with hash {item_hash}."
             logging.error(err)
             return create_json_response(str(err), 400)
-        logging.info("Retrieved %s: %d bytes", item_hash, len(content))
+        logging.info(f"Retrieved {item_hash}: {len(content)} bytes")
         return content
     return vcs_handler.fetchCommitData(commit_hash)
     # except Exception as err:
@@ -127,8 +127,7 @@ def start():
         app.logger.setLevel(logging.INFO)
 
     if "GITHUB_ACCESS_TOKEN" in vcs_config:
-        app.config["GITHUB_API_ACCESS_TOKEN"] = vcs_config[
-            "GITHUB_ACCESS_TOKEN"]
+        app.config["GITHUB_API_ACCESS_TOKEN"] = vcs_config["GITHUB_ACCESS_TOKEN"]
 
     cert_dir = os.path.join(root_dir, "cert")
     cert_file = os.path.join(cert_dir, "cert.pem")
@@ -138,8 +137,7 @@ def start():
     use_host = "0.0.0.0"
     use_port = 8088
     use_protocol = "https" if ssl_context else "http"
-    print("[+] Listening on: {}://{}:{}".format(use_protocol, use_host,
-                                                use_port))
+    print(f"[+] Listening on: {use_protocol}://{use_host}:{use_port}")
     app.run(host=use_host, port=use_port, ssl_context=ssl_context, debug=DEBUG)
 
 

--- a/lib/app_factory.py
+++ b/lib/app_factory.py
@@ -50,7 +50,6 @@ def create_app(test_config=None):
 
 
 def register_route_checks(app):
-
     def maintenance_check():
         if not cfg.MAINTENANCE_MODE:
             return

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -54,9 +54,7 @@ def manually_read_app_config():
 
 
 def measure_execution_time(label):
-
     def decorator(func):
-
         def wrapper(*args, **kwargs):
             start = time.time()
             res = func(*args, **kwargs)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -62,7 +62,7 @@ def measure_execution_time(label):
             res = func(*args, **kwargs)
             end = time.time()
 
-            print("[{}] {}s elapsed".format(label, end - start))
+            print(f"[{label}] {end - start}s elapsed")
             return res
 
         return wrapper

--- a/lib/vcs_handler/__init__.py
+++ b/lib/vcs_handler/__init__.py
@@ -16,8 +16,4 @@ from os.path import dirname, basename, isfile
 import glob
 
 modules = glob.glob(dirname(__file__) + "/*.py")
-__all__ = [
-    basename(f)[:-3]
-    for f in modules
-    if isfile(f) and not f.endswith("__init__.py")
-]
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith("__init__.py")]

--- a/lib/vcs_handler/github_handler.py
+++ b/lib/vcs_handler/github_handler.py
@@ -99,14 +99,11 @@ class GithubHandler(VcsHandler):
     def getFileProviderUrl(self):
         owner = self.repo_owner
         repo = self.repo_name
-        HASH_PLACEHOLDER = HASH_PLACEHOLDER,
         return f"https://api.github.com/repos/{owner}/{repo}/git/blobs/{HASH_PLACEHOLDER}"
 
     def getRefFileProviderUrl(self):
         owner = self.repo_owner
         repo = self.repo_name
-        PATH_PLACEHOLDER = PATH_PLACEHOLDER
-        HASH_PLACEHOLDER = HASH_PLACEHOLDER
         return f"https://api.github.com/repos/{owner}/{repo}/contents/{PATH_PLACEHOLDER}?ref={HASH_PLACEHOLDER}"
 
     def getFileUrl(self):

--- a/lib/vcs_handler/github_handler.py
+++ b/lib/vcs_handler/github_handler.py
@@ -60,16 +60,13 @@ class GithubHandler(VcsHandler):
 
     def parseResourceURL(self, resource_url):
         if not resource_url:
-            raise InvalidIdentifierException(
-                "Please provide a Github commit link.")
+            raise InvalidIdentifierException("Please provide a Github commit link.")
         url_data = urlparse(resource_url)
         git_path = url_data.path
         matches = re.match(r"/([^/]+)/([^/]+)/commit/([^/]+)/?$", git_path)
-        if (not url_data.hostname or "github.com" not in url_data.hostname or
-                not matches):
+        if (not url_data.hostname or "github.com" not in url_data.hostname or not matches):
             raise InvalidIdentifierException(
-                "Please provide a valid (https://github.com/{owner}/{repo}/commit/{hash}) commit link."
-            )
+                "Please provide a valid (https://github.com/{owner}/{repo}/commit/{hash}) commit link.")
         self.repo_owner, self.repo_name, self.commit_hash = matches.groups()
         self.commit_link = resource_url
 
@@ -88,65 +85,58 @@ class GithubHandler(VcsHandler):
             if patched_file.patch is not None:
                 patch_str.write(patched_file.patch)
             patch_str.seek(0)
-            logging.debug("Parsing diff\n%s", patch_str.getvalue())
+            logging.debug(f"Parsing diff\n{patch_str.getvalue()}")
             patch = PatchSet(patch_str, encoding=None)
 
             for hunk in patch[0]:
                 for line in hunk:
                     if line.is_context:
                         continue
-                    patched_files[patched_file.filename]["deltas"].append(
-                        vars(line))
+                    patched_files[patched_file.filename]["deltas"].append(vars(line))
 
         return patched_files
 
     def getFileProviderUrl(self):
-        return "https://api.github.com/repos/{owner}/{repo}/git/blobs/{HASH_PLACEHOLDER}".format(
-            owner=self.repo_owner,
-            repo=self.repo_name,
-            HASH_PLACEHOLDER=HASH_PLACEHOLDER,
-        )
+        owner = self.repo_owner
+        repo = self.repo_name
+        HASH_PLACEHOLDER = HASH_PLACEHOLDER,
+        return f"https://api.github.com/repos/{owner}/{repo}/git/blobs/{HASH_PLACEHOLDER}"
 
     def getRefFileProviderUrl(self):
-        return "https://api.github.com/repos/{owner}/{repo}/contents/{PATH_PLACEHOLDER}?ref={HASH_PLACEHOLDER}".format(
-            owner=self.repo_owner,
-            repo=self.repo_name,
-            PATH_PLACEHOLDER=PATH_PLACEHOLDER,
-            HASH_PLACEHOLDER=HASH_PLACEHOLDER,
-        )
+        owner = self.repo_owner
+        repo = self.repo_name
+        PATH_PLACEHOLDER = PATH_PLACEHOLDER
+        HASH_PLACEHOLDER = HASH_PLACEHOLDER
+        return f"https://api.github.com/repos/{owner}/{repo}/contents/{PATH_PLACEHOLDER}?ref={HASH_PLACEHOLDER}"
 
     def getFileUrl(self):
-        return "https://github.com/{owner}/{repo}/blob/{commit_hash}/".format(
-            owner=self.repo_owner,
-            repo=self.repo_name,
-            commit_hash=self.commit_hash)
+        owner = self.repo_owner
+        repo = self.repo_name
+        commit_hash = self.commit_hash
+        return f"https://github.com/{owner}/{repo}/blob/{commit_hash}/"
 
     def getTreeUrl(self):
-        return "https://github.com/{owner}/{repo}/tree/{commit_hash}/".format(
-            owner=self.repo_owner,
-            repo=self.repo_name,
-            commit_hash=self.commit_hash)
+        owner = self.repo_owner,
+        repo = self.repo_name,
+        commit_hash = self.commit_hash
+        return f"https://github.com/{owner}/{repo}/tree/{commit_hash}/"
 
     def _getFilesMetadata(self, github_files_metadata):
         files_metadata = []
         for file in github_files_metadata:
-            file_metadata = CommitFilesMetadata(file.filename, file.status,
-                                                file.additions, file.deletions)
+            file_metadata = CommitFilesMetadata(file.filename, file.status, file.additions, file.deletions)
             files_metadata.append(file_metadata)
         return files_metadata
 
     def _getPatchStats(self, commit_stats):
-        return CommitStats(commit_stats.additions, commit_stats.deletions,
-                           commit_stats.total)
+        return CommitStats(commit_stats.additions, commit_stats.deletions, commit_stats.total)
 
     def fetchCommitData(self, commit_hash=None):
         """Args:
+        commit_hash:
 
-      commit_hash:
-
-    Returns:
-
-    """
+        Returns:
+        """
         if not commit_hash:
             commit_hash = self.commit_hash
 
@@ -156,8 +146,7 @@ class GithubHandler(VcsHandler):
             return cache_content
 
         # Fetch relevant information from Github.
-        github_repo = self.github.get_repo("{owner}/{repo}".format(
-            owner=self.repo_owner, repo=self.repo_name))
+        github_repo = self.github.get_repo(f"{self.repo_owner}/{self.repo_name}")
         commit = github_repo.get_commit(commit_hash)
         commit_parents = commit.commit.parents
         parent_commit_hash = commit_hash
@@ -167,14 +156,13 @@ class GithubHandler(VcsHandler):
         # Fetch the list of all files in the previous "vulnerable" state.
         # Note: We use recursive=False (default) to only fetch the highest layer.
         git_tree = github_repo.get_git_tree(parent_commit_hash)
-        """commit_url = commit.html_url commit_message = commit.commit.message affected_files = commit.files commit_parents = commit.commit.parents"""
+        # commit_url = commit.html_url commit_message = commit.commit.message affected_files = commit.files commit_parents = commit.commit.parents
         patched_files = self._ParsePatchPerFile(commit.files)
 
         commit_stats = self._getPatchStats(commit.stats)
         files_metadata = self._getFilesMetadata(commit.files)
 
-        commit_date = int((commit.commit.committer.date -
-                           datetime.datetime(1970, 1, 1)).total_seconds())
+        commit_date = int((commit.commit.committer.date - datetime.datetime(1970, 1, 1)).total_seconds())
         commit_metadata = CommitMetadata(
             parent_commit_hash,
             commit_date,

--- a/lib/vcs_handler/github_handler.py
+++ b/lib/vcs_handler/github_handler.py
@@ -44,7 +44,6 @@ CACHE_DIR = "cache/"
 
 
 class GithubHandler(VcsHandler):
-
     def __init__(self, app, resource_url):
         """Initializes the questionnaire object."""
         super(GithubHandler, self).__init__(app, resource_url)

--- a/lib/vcs_handler/gitrepo_handler.py
+++ b/lib/vcs_handler/gitrepo_handler.py
@@ -63,7 +63,6 @@ class GitTreeElement:
 
 def _file_list_dulwich(repo, tgt_env, recursive=False):
     """Get file list using dulwich"""
-
     def _traverse(tree, repo_obj, blobs, prefix):
         """Traverse through a dulwich Tree object recursively, accumulating all the blob paths within it in the "blobs" list"""
         for item in list(tree.items()):
@@ -95,7 +94,6 @@ def _file_list_dulwich(repo, tgt_env, recursive=False):
 
 
 class GitRepoHandler(VcsHandler):
-
     def __init__(self, app, resource_url):
         """Initializes the questionnaire object."""
         super(GitRepoHandler, self).__init__(app, resource_url)

--- a/lib/vcs_handler/gitrepo_handler.py
+++ b/lib/vcs_handler/gitrepo_handler.py
@@ -52,8 +52,7 @@ REPO_PATH = "vulnerable_code/"
 
 # [SCHEMA]://[HOST]/[PATH].git#[COMMIT_HASH]
 # [SCHEMA]://[HOST]/[PATH].git@[COMMIT_HASH]
-URL_RE = re.compile(
-    r"^(?P<url>.*/(?P<name>[^/]+).git)(?:[#@](?P<commit>[a-fA-Z0-9]{7,}))?$")
+URL_RE = re.compile(r"^(?P<url>.*/(?P<name>[^/]+).git)(?:[#@](?P<commit>[a-fA-Z0-9]{7,}))?$")
 
 
 class GitTreeElement:
@@ -110,8 +109,7 @@ class GitRepoHandler(VcsHandler):
         matches = URL_RE.search(resource_url)
         if not matches:
             raise InvalidIdentifierException(
-                "Please provide a valid ([SCHEMA]://[HOST]/[PATH].git#[COMMIT_HASH]) Git Repo link."
-            )
+                "Please provide a valid ([SCHEMA]://[HOST]/[PATH].git#[COMMIT_HASH]) Git Repo link.")
         self.repo_name = matches.group("name")
         self.repo_name = os.path.basename(self.repo_name)
         self.repo_url = matches.group("url")
@@ -132,8 +130,7 @@ class GitRepoHandler(VcsHandler):
     def _getPatcheSet(self, old_commit, new_commit):
 
         patch_diff = BytesIO()
-        write_tree_diff(patch_diff, self.repo.object_store, old_commit.tree,
-                        new_commit.tree)
+        write_tree_diff(patch_diff, self.repo.object_store, old_commit.tree, new_commit.tree)
         patch_diff.seek(0)
         patch = PatchSet(patch_diff, encoding="utf-8")
         return patch
@@ -153,17 +150,15 @@ class GitRepoHandler(VcsHandler):
         )
         repo_path = os.path.normpath(repo_path)
         if not repo_path.startswith(REPO_PATH + repo_hostname):
-            self._logError("Invalid path: %r + %r => %r", self.repo_url,
-                           self.repo_name, repo_path)
+            self._logError(f"Invalid path: {self.repo_name} + {self.repo_name} => {repo_path}")
             raise Exception("Can't clone repo. Invalid repository.")
 
         if not os.path.isdir(repo_path):
             # Using GitPython here since Dulwich was throwing weird errors like:
             # "IOError: Not a gzipped file" when fetching resources like:
             # https://git.centos.org/r/rpms/dhcp.git
-            if not GitPythonRepo.clone_from(
-                    self.repo_url, repo_path, bare=True):
-                self._logError("Can't clone repo {:s}.".format(self.repo_name))
+            if not GitPythonRepo.clone_from(self.repo_url, repo_path, bare=True):
+                self._logError(f"Can't clone repo {self.repo_name}.")
                 raise Exception("Can't clone repo.")
 
         self.repo = Repo(repo_path)
@@ -205,8 +200,7 @@ class GitRepoHandler(VcsHandler):
             elif file.is_removed_file:
                 status = "removed"
 
-            file_metadata = CommitFilesMetadata(file.path, status, file.added,
-                                                file.removed)
+            file_metadata = CommitFilesMetadata(file.path, status, file.added, file.removed)
             files_metadata.append(file_metadata)
         return files_metadata
 
@@ -231,8 +225,7 @@ class GitRepoHandler(VcsHandler):
             commit_hash = self.commit_hash
 
         if not commit_hash:
-            self._logError("No commit_hash provided for repo URL: {:s}.".format(
-                self.repo_url))
+            self._logError(f"No commit_hash provided for repo URL: {self.repo_url}.")
             raise Exception("Please provide a commit_hash.")
 
         # py 3 compatiblity. Dulwich expects hashes to be bytes
@@ -243,15 +236,11 @@ class GitRepoHandler(VcsHandler):
             return None
 
         if commit_hash not in self.repo:
-            self._logError(
-                "Can't find commit_hash {} in given repo. Fetching updates and retry."
-                .format(commit_hash))
+            self._logError(f"Can't find commit_hash {commit_hash} in given repo. Fetching updates and retry.")
             self._fetch_remote()
 
         if commit_hash not in self.repo:
-            self._logError(
-                "Can't find commit_hash {} in given repo. Cancelling request."
-                .format(commit_hash))
+            self._logError(f"Can't find commit_hash {commit_hash} in given repo. Cancelling request.")
             raise Exception("Can't find commit_hash in given repo.")
 
         commit = self.repo[commit_hash]
@@ -270,11 +259,9 @@ class GitRepoHandler(VcsHandler):
         patched_files = {}
         for file in patch_files_metadata:
             if file.status == "added":
-                patched_file_sha = self._getItemHashFromPath(
-                    commit_hash, file.path)
+                patched_file_sha = self._getItemHashFromPath(commit_hash, file.path)
             else:
-                patched_file_sha = self._getItemHashFromPath(
-                    parent_commit_hash, file.path)
+                patched_file_sha = self._getItemHashFromPath(parent_commit_hash, file.path)
             patched_files[file.path] = {
                 "status": file.status,
                 "sha": patched_file_sha,

--- a/lib/vcs_handler/vcs_handler.py
+++ b/lib/vcs_handler/vcs_handler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 
 HASH_PLACEHOLDER = "--ITEM_HASH--"
 PATH_PLACEHOLDER = "--PATH_PLACE--"

--- a/lib/vcs_handler/vcs_handler.py
+++ b/lib/vcs_handler/vcs_handler.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 HASH_PLACEHOLDER = "--ITEM_HASH--"
 PATH_PLACEHOLDER = "--PATH_PLACE--"
 VULN_ID_PLACEHOLDER = "--ID_PLACE--"
 
 
 class CommitStats(object):
-
     def __init__(self, additions, deletions, total):
         self.additions = additions
         self.deletions = deletions
@@ -27,7 +25,6 @@ class CommitStats(object):
 
 
 class CommitFilesMetadata(object):
-
     def __init__(self, path, status, additions, deletions):
         self.path = path
         self.status = status
@@ -36,7 +33,6 @@ class CommitFilesMetadata(object):
 
 
 class CommitMetadata(object):
-
     def __init__(self, parent_commit_hash, date, message, stats, files_metadata):
         self.parent_commit_hash = parent_commit_hash
         self.date = date
@@ -46,7 +42,6 @@ class CommitMetadata(object):
 
 
 class VcsHandler(object):
-
     def __init__(self, app, resource_url):
         self.app = app
         self.resource_url = resource_url

--- a/lib/vcs_handler/vcs_handler.py
+++ b/lib/vcs_handler/vcs_handler.py
@@ -38,8 +38,7 @@ class CommitFilesMetadata(object):
 
 class CommitMetadata(object):
 
-    def __init__(self, parent_commit_hash, date, message, stats,
-                 files_metadata):
+    def __init__(self, parent_commit_hash, date, message, stats, files_metadata):
         self.parent_commit_hash = parent_commit_hash
         self.date = date
         self.message = message
@@ -104,9 +103,5 @@ class VcsHandler(object):
             }
             files.append(file)
 
-        data = {
-            "commit": commit_data,
-            "patched_files": patched_files,
-            "files": files
-        }
+        data = {"commit": commit_data, "patched_files": patched_files, "files": files}
         return data

--- a/lib/vcs_management.py
+++ b/lib/vcs_management.py
@@ -25,14 +25,15 @@ from app.exceptions import InvalidIdentifierException
 
 
 def get_inheritor_clases(klass):
-    """Returns a list of all defined and valid vcs handlers.
+    """
+    Returns a list of all defined and valid vcs handlers.
 
-  Args:
+    Args:
     klass: Name of parent class.
 
-  Returns:
+    Returns:
     List: Defined vcs handlers.
-  """
+    """
     subclasses = set()
     work = [klass]
     while work:
@@ -45,24 +46,23 @@ def get_inheritor_clases(klass):
 
 
 def get_vcs_handler(app, resource_url):
-    """Tries to instantiate a vcs handler with teh given resource url.
+    """
+    Tries to instantiate a vcs handler with teh given resource url.
 
-  Args:
+    Args:
     app:
     resource_url:
 
-  Returns:
+    Returns:
     Null|VCS object: A valid vcs handler if available.
-  """
+    """
     new_handler = None
     vcs_handlers = get_inheritor_clases(VcsHandler)
     for vcs_handler in vcs_handlers:
         try:
             new_handler = vcs_handler(app, resource_url)
-            logging.debug("Parsing %s with %s succeeded", resource_url,
-                          vcs_handler.__name__)
+            logging.debug(f"Parsing {resource_url} with {vcs_handler.__name__} succeeded")
         except InvalidIdentifierException as e:
-            logging.debug("Parsing %s with %s failed: %s", resource_url,
-                          vcs_handler.__name__, e)
+            logging.debug(f"Parsing {resource_url} with {vcs_handler.__name__} failed: {e}")
             pass
     return new_handler

--- a/main.py
+++ b/main.py
@@ -14,17 +14,16 @@
 # limitations under the License.
 
 import os
+import sys
 import logging
 from logging.handlers import RotatingFileHandler
-import sys
-
-from flask import (send_from_directory, render_template)
 
 import alembic.script
 import alembic.runtime.environment
 from lib.utils import manually_read_app_config
+from flask import (send_from_directory, render_template)
 
-if not "MYSQL_CONNECTION_NAME" in os.environ:
+if "MYSQL_CONNECTION_NAME" not in os.environ:
     print("[~] Executed outside AppEngine context. Manually loading config.")
     manually_read_app_config()
 
@@ -32,6 +31,7 @@ from app.vulnerability.views.vulncode_db import VulncodeDB
 import cfg
 from data.database import DEFAULT_DATABASE
 from lib.app_factory import create_app
+
 app = create_app()
 db = DEFAULT_DATABASE.db
 
@@ -67,21 +67,18 @@ def check_db_state():
         head_revs = frozenset(rev.revision for rev in heads)
 
         def check(rev, context):
-            db_revs = frozenset(
-                rev.revision for rev in script.get_all_current(rev))
+            db_revs = frozenset(rev.revision for rev in script.get_all_current(rev))
             if db_revs ^ head_revs:
                 config.print_stdout(
                     "Current revision(s) for %s %s do not match the heads %s\n.Run ./manage.sh db upgrade.",
-                    alembic.util.obfuscate_url_pw(
-                        context.connection.engine.url),
+                    alembic.util.obfuscate_url_pw(context.connection.engine.url),
                     tuple(db_revs),
                     tuple(head_revs),
                 )
                 sys.exit(1)
             return []
 
-        with alembic.runtime.environment.EnvironmentContext(
-                config, script, fn=check):
+        with alembic.runtime.environment.EnvironmentContext(config, script, fn=check):
             script.run_env()
 
 
@@ -114,8 +111,7 @@ def main():
     use_host = "0.0.0.0"
     use_port = 8080
     use_protocol = "https" if ssl_context else "http"
-    print("[+] Listening on: {}://{}:{}".format(use_protocol, use_host,
-                                                use_port))
+    print(f"[+] Listening on: {use_protocol}://{use_host}:{use_port}")
     app.run(host=use_host, port=use_port, ssl_context=ssl_context, debug=True)
 
 

--- a/tests/app_tests/vulnerability/views/test_vulnerability.py
+++ b/tests/app_tests/vulnerability/views/test_vulnerability.py
@@ -22,9 +22,7 @@ from data.models import Vulnerability, VulnerabilityGitCommits, Nvd
 
 
 class VulnerabilityDataTest(FlaskTest):
-
     def generate_testdata(self):
-
         def generate_commit_data():
             return VulnerabilityGitCommits(
                 commit_link='https://github.com/0WN3R/REP0',
@@ -33,8 +31,10 @@ class VulnerabilityDataTest(FlaskTest):
                 repo_owner='0WN3R',
             )
 
-        self.vuln1 = Vulnerability(
-            cve_id='CVE-1337', commits=[generate_commit_data()], comment="Test comment.", date_created=datetime.date.today())
+        self.vuln1 = Vulnerability(cve_id='CVE-1337',
+                                   commits=[generate_commit_data()],
+                                   comment="Test comment.",
+                                   date_created=datetime.date.today())
         self.nvd1 = Nvd(cve_id='CVE-1337', published_date=datetime.date.today(), descriptions=[])
         self.vuln2 = Vulnerability(
             cve_id='CVE-1339',
@@ -63,7 +63,6 @@ class VulnerabilityDataTest(FlaskTest):
 
 
 class TestVulnerbility(VulnerabilityDataTest):
-
     @mock.patch('data.models.Vulnerability.get_by_commit_hash')
     @mock.patch('data.models.Vulnerability.get_by_cve_id')
     def test_getVulnerability(self, get_by_cve_id_mock, get_by_commit_hash_mock):
@@ -79,7 +78,6 @@ class TestVulnerbility(VulnerabilityDataTest):
 
 
 class VulnerabilityViewTests(VulnerabilityDataTest):
-
     @classmethod
     def setUpClass(self):
         super(VulnerabilityViewTests, self).setUpClass()

--- a/tests/app_tests/vulnerability/views/test_vulnerability.py
+++ b/tests/app_tests/vulnerability/views/test_vulnerability.py
@@ -34,14 +34,8 @@ class VulnerabilityDataTest(FlaskTest):
             )
 
         self.vuln1 = Vulnerability(
-            cve_id='CVE-1337',
-            commits=[generate_commit_data()],
-            comment="Test comment.",
-            date_created=datetime.date.today())
-        self.nvd1 = Nvd(
-            cve_id='CVE-1337',
-            published_date=datetime.date.today(),
-            descriptions=[])
+            cve_id='CVE-1337', commits=[generate_commit_data()], comment="Test comment.", date_created=datetime.date.today())
+        self.nvd1 = Nvd(cve_id='CVE-1337', published_date=datetime.date.today(), descriptions=[])
         self.vuln2 = Vulnerability(
             cve_id='CVE-1339',
             commits=[generate_commit_data()],
@@ -51,8 +45,7 @@ class VulnerabilityDataTest(FlaskTest):
 
         self.vulns = [self.vuln1, self.vuln2]
 
-        self.vuln_view1 = vuln.VulnerabilityView(
-            self.vuln1, self.nvd1, preview=True)
+        self.vuln_view1 = vuln.VulnerabilityView(self.vuln1, self.nvd1, preview=True)
         self.vuln_view2 = vuln.VulnerabilityView(self.vuln1, None, preview=True)
         self.vuln_view3 = vuln.VulnerabilityView(None, self.nvd1, preview=True)
 
@@ -73,8 +66,7 @@ class TestVulnerbility(VulnerabilityDataTest):
 
     @mock.patch('data.models.Vulnerability.get_by_commit_hash')
     @mock.patch('data.models.Vulnerability.get_by_cve_id')
-    def test_getVulnerability(self, get_by_cve_id_mock,
-                              get_by_commit_hash_mock):
+    def test_getVulnerability(self, get_by_cve_id_mock, get_by_commit_hash_mock):
         get_by_cve_id_mock.side_effect = [self.vuln1]
         actual_vuln = vuln.getVulnerability({"cve_id": 'CVE-1337'})
         get_by_cve_id_mock.assert_called_once_with('CVE-1337')

--- a/tests/lib_tests/test_utils.py
+++ b/tests/lib_tests/test_utils.py
@@ -20,7 +20,6 @@ from lib.utils import get_file_contents
 
 
 class TestUtils(unittest.TestCase):
-
     def setUp(self):
         pass
 

--- a/tests/lib_tests/test_utils.py
+++ b/tests/lib_tests/test_utils.py
@@ -32,9 +32,7 @@ class TestUtils(unittest.TestCase):
         dummy_data = "data"
         dummy_path = "/var/path/file.txt"
 
-        mock_open.side_effect = [
-            mock.mock_open(read_data=dummy_data).return_value
-        ]
+        mock_open.side_effect = [mock.mock_open(read_data=dummy_data).return_value]
         actual_data = get_file_contents(dummy_path)
         self.assertEqual(actual_data, dummy_data)
         mock_open.assert_called_once_with(dummy_path)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,7 +28,6 @@ TEST_CONFIG = {'TESTING': True, 'WTF_CSRF_ENABLED': False, 'DEBUG': True, 'SQLAL
 
 
 class FlaskTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         app = create_app(TEST_CONFIG)
@@ -47,7 +46,6 @@ class FlaskTest(unittest.TestCase):
 
 
 class FlaskIntegrationTest(FlaskTest):
-
     @classmethod
     def setUpClass(cls):
         TEST_CONFIG['SQLALCHEMY_DATABASE_URI'] = DOCKER_DB_URI

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,12 +24,7 @@ with open(os.path.join(cfg.BASE_DIR, "docker/db_schema.sql"), "rb") as f:
     _create_schemas_sql = f.read().decode("utf8")
 
 DOCKER_DB_URI = 'mysql+mysqldb://root:test_db_pass@tests-db:3306/main'
-TEST_CONFIG = {
-    'TESTING': True,
-    'WTF_CSRF_ENABLED': False,
-    'DEBUG': True,
-    'SQLALCHEMY_DATABASE_URI': None
-}
+TEST_CONFIG = {'TESTING': True, 'WTF_CSRF_ENABLED': False, 'DEBUG': True, 'SQLALCHEMY_DATABASE_URI': None}
 
 
 class FlaskTest(unittest.TestCase):


### PR DESCRIPTION
## Coding style 
- Use Python3.6 format-strings when relevant **_Note that this wont't work on python versions lower than 3.6_**. This results in a more intuitive syntax.
- Extend max line lenght to 128 (also in yapf), updating E501 of PEP8 Standards.
- Making most of the codebase PEP8 compliant