### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,28 +2,27 @@
 # 'MySQLdb' dependency.
 mysqlclient>=1.4.2
 # Main Flask related dependencies.
-Flask==1.0.2
+Flask==1.1.1
 Flask-Bootstrap==3.3.7.1
-flask-marshmallow==0.9.0
-Flask-Migrate==2.2.1
+flask-marshmallow==0.10.1
+Flask-Migrate>=2.2.1
 Flask-OAuthlib==0.9.5
 # Pin this until https://github.com/lepture/flask-oauthlib/pull/388 is released
 requests-oauthlib>=0.6.2,<1.2.0
-Flask-Script==2.0.6
-Flask-SQLAlchemy==2.4.0
+Flask-Script>=2.0.6
+Flask-SQLAlchemy>=2.4.0
 # Not in use due to a problem when matching against multiple fulltext columns with a joined table.
 # SQLAlchemy-FullText-Search==0.2.5
-Flask-WTF==0.14.2
-Werkzeug==0.14.1
-marshmallow-sqlalchemy==0.14.0
+Flask-WTF>=0.14.2
+marshmallow-sqlalchemy==0.17.0
 google-auth==1.6.1
 # Flask-debugtoolbar requirements -------
-flask-debugtoolbar==0.10.1
-setuptools==40.6.3
-sqlparse==0.2.4
-pygments==2.3.1
-pandas==0.24.2
-colorama==0.4.1
+flask-debugtoolbar>=0.10.1
+setuptools>=40.6.3
+sqlparse==0.3.0
+pygments==2.4.2
+pandas==0.25.1
+colorama>=0.4.1
 # Provides a WSGI werkzeug server alternative.
 #gevent==1.4.0
 # Required to make Flask's jsonify work with decimal numbers.

--- a/vcs_requirements.txt
+++ b/vcs_requirements.txt
@@ -1,6 +1,6 @@
 dulwich>=0.19,<0.20
 gitpython==2.1.11
-Flask==1.0.2
+Flask==1.1.1
 PyGithub==1.40
 unidiff==0.5.5
 pyyaml


### PR DESCRIPTION
## Fixes
- Issue #9 : ModuleNotFoundError: No module named 'marshmallow.compat'
- CVE-2019-14806 affecting werkzeug < 0.15.3

## Improves
- updated modules

__Any feedback/additional testing welcome__