### PR TITLE
Fix ANSI escape character on POSIX

### DIFF
--- a/docker/docker-admin.sh
+++ b/docker/docker-admin.sh
@@ -38,15 +38,15 @@ function die () {
 }
 
 function info() {
-  echo -e "[\e[94m*\e[0m]" "$@"
+  echo -e "[\033[94m*\033[0m]" "$@"
 }
 
 function error() {
-  echo -e "[\e[91m!\e[0m]" "$@"
+  echo -e "[\033[91m!\033[0m]" "$@"
 }
 
 function success() {
-  echo -e "[\e[92m+\e[0m]" "$@"
+  echo -e "[\033[92m+\033[0m]" "$@"
 }
 
 function fatal() {

--- a/format.sh
+++ b/format.sh
@@ -15,15 +15,15 @@
 
 
 function info() {
-  echo -e "[\e[94m*\e[0m]" "$@"
+  echo -e "[\033[94m*\033[0m]" "$@"
 }
 
 function error() {
-  echo -e "[\e[91m!\e[0m]" "$@"
+  echo -e "[\033[91m!\033[0m]" "$@"
 }
 
 function success() {
-  echo -e "[\e[92m+\e[0m]" "$@"
+  echo -e "[\033[92m+\033[0m]" "$@"
 }
 
 function fatal() {

--- a/lint.sh
+++ b/lint.sh
@@ -15,15 +15,15 @@
 
 
 function info() {
-  echo -e "[\e[94m*\e[0m]" "$@"
+  echo -e "[\033[94m*\033[0m]" "$@"
 }
 
 function error() {
-  echo -e "[\e[91m!\e[0m]" "$@"
+  echo -e "[\033[91m!\033[0m]" "$@"
 }
 
 function success() {
-  echo -e "[\e[92m+\e[0m]" "$@"
+  echo -e "[\033[92m+\033[0m]" "$@"
 }
 
 function fatal() {

--- a/manage.sh
+++ b/manage.sh
@@ -16,7 +16,7 @@
 
 if ! which flask &>/dev/null
 then
-  echo -e "\e[91mflask not found. Rerun this script within the virtual environment.\e[m"
+  echo -e "\033[91mflask not found. Rerun this script within the virtual environment.\033[m"
   exit 1
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 function info() {
-  echo -e "[\e[94m*\e[0m]" "$@"
+  echo -e "[\033[94m*\033[0m]" "$@"
 }
 
 if [[ ! -d "migrations/versions" || ! $(ls -A migrations/versions) ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -14,15 +14,15 @@
 # limitations under the License.
 
 function info() {
-  echo -e "[\e[94m*\e[0m]" "$@"
+  echo -e "[\033[94m*\033[0m]" "$@"
 }
 
 function error() {
-  echo -e "\t[\e[91m!\e[0m]" "$@"
+  echo -e "\t[\033[91m!\033[0m]" "$@"
 }
 
 function success() {
-  echo -e "\t[\e[92m+\e[0m]" "$@"
+  echo -e "\t[\033[92m+\033[0m]" "$@"
 }
 
 function fatal() {


### PR DESCRIPTION
It seems like the escape `\e` is not part of the POSIX standard. Therefore on macOS you will experience outputs like `[\e[92m+\e[0m] Done`

Changing to the octal escape code `\033` [like python colorama](https://github.com/tartley/colorama/blob/master/colorama/ansi.py) fixes the issue.