### PR TITLE
Fix database credentials when frontend is run with docker

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -68,8 +68,8 @@ elif IS_QA:
     GCE_VCS_PROXY_URL = os.environ["VCS_PROXY_QA_URL"]
 elif IS_LOCAL:
     DEBUG = True
-    MYSQL_USER = os.getenv("MYSQL_LOCAL_USER", "")
-    MYSQL_PASS = os.getenv("MYSQL_LOCAL_PASS", "")
+    MYSQL_USER = os.getenv("MYSQL_LOCAL_USER", "root")
+    MYSQL_PASS = os.getenv("MYSQL_LOCAL_PASS", "pass")
     GCE_VCS_PROXY_URL = os.getenv("VCS_PROXY_LOCAL_URL", "")
 else:
     raise AssertionError("Invalid deployment mode detected.")


### PR DESCRIPTION
When running VCBD with docker using this sequence :
- `./setup.bash`
- `./docker/docker-admin.sh init`
- `./docker/docker-admin.sh crawl_patches`

Running `crawl_patches` using `docker-admin.sh` will fail at some point due to database credentials environment variables not being passed to the frontend container.
```
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (1045, "Access denied for user 'root'@'172.18.0.4' (using password: NO)")
```

Setting the default environment variable value seems LGTM but there might be better designs to consider.
