### PR TITLE
flask-marshmallow>=0.12.0

### DIFF
--- a/data/models/vulnerability.py
+++ b/data/models/vulnerability.py
@@ -166,7 +166,7 @@ class RevisionMixin:
         }
 
 
-class MarshmallowBase(ma.ModelSchema):
+class MarshmallowBase(ma.SQLAlchemyAutoSchema):
 
     __abstract__ = True
 

--- a/data/utils.py
+++ b/data/utils.py
@@ -27,6 +27,6 @@ def populate_models(modname):
     for name, clazz in inspect.getmembers(mod, inspect.isclass):
         # getattr can't be used here as it also looks into superclasses
         is_abstract = clazz.__dict__.get("__abstract__", False)
-        if issubclass(clazz, (db.Model, ma.ModelSchema)) and not is_abstract:
+        if issubclass(clazz, (db.Model, ma.SQLAlchemyAutoSchema)) and not is_abstract:
             names.append(name)
     return names

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mysqlclient>=1.4.6
 # Main Flask related dependencies.
 Flask>=1.1.2
 Flask-Bootstrap==3.3.7.1
-flask-marshmallow==0.10.1
+flask-marshmallow>=0.12.0
 Flask-Migrate>=2.2.1
 Authlib>=0.15.2
 Flask-Script>=2.0.6


### PR DESCRIPTION
With the release of Flask-Marshmallow 0.12.0 (2020-04-26), the ma.ModelSchema got depreceated. You should be switching to ma.SQLAlchemySchema or ma.SQLAlchemyAutoSchema.

See more at https://flask-marshmallow.readthedocs.io/en/latest/changelog.html#id2